### PR TITLE
Add Logic to Auto-populate Notebooks from Context Menu

### DIFF
--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -67,6 +67,7 @@ import {
   handleDataToVisualReportSourceChange,
   getNotebooksOptions,
   getNotebooksBaseUrlCreate,
+  getReportSourceFromContextMenu,
 } from './report_settings_helpers';
 import { TimeRangeSelect } from './time_range';
 import { converter } from '../utils';
@@ -489,11 +490,20 @@ export function ReportSettings(props: ReportSettingProps) {
       }
     }
   }
+
+  const setNotebookFromInContextMenu = (response, id) => {
+    for (let index = 0; index < response.notebooks.length; ++index) {
+      if (id === response.notebooks[index].value) {
+        setNotebooksSourceSelect([response.notebooks[index]]);
+      }
+    }
+  }
  
   const setInContextDefaultConfiguration = (response) => {
     const url = window.location.href;
+    const source = getReportSourceFromContextMenu(url);
     const id = parseInContextUrl(url, 'id');
-    if (url.includes('dashboard')) {
+    if (source === 'dashboard') {
       setReportSourceId('dashboardReportSource');
       reportDefinitionRequest.report_params.report_source =
         REPORT_SOURCE_RADIOS[0].label;
@@ -501,7 +511,7 @@ export function ReportSettings(props: ReportSettingProps) {
       setDashboardFromInContextMenu(response, id);
       reportDefinitionRequest.report_params.core_params.base_url =
         getDashboardBaseUrlCreate(edit, id, true) + id;
-    } else if (url.includes('visualize')) {
+    } else if (source === 'visualize') {
       setReportSourceId('visualizationReportSource');
       reportDefinitionRequest.report_params.report_source =
         REPORT_SOURCE_RADIOS[1].label;
@@ -509,7 +519,7 @@ export function ReportSettings(props: ReportSettingProps) {
       setVisualizationFromInContextMenu(response, id);
       reportDefinitionRequest.report_params.core_params.base_url =
         getVisualizationBaseUrlCreate(edit, editDefinitionId, true) + id;
-    } else if (url.includes('discover')) {
+    } else if (source === 'discover') {
       setReportSourceId('savedSearchReportSource');
       reportDefinitionRequest.report_params.core_params.report_format = 'csv';
       reportDefinitionRequest.report_params.core_params.saved_search_id = id;
@@ -519,6 +529,16 @@ export function ReportSettings(props: ReportSettingProps) {
       setSavedSearchFromInContextMenu(response, id)
       reportDefinitionRequest.report_params.core_params.base_url =
         getSavedSearchBaseUrlCreate(edit, editDefinitionId, true) + id;
+    } else if (source === 'notebook') {
+      setReportSourceId('notebooksReportSource');
+      reportDefinitionRequest.report_params.report_source = 
+        REPORT_SOURCE_RADIOS[3].label;
+
+      setNotebookFromInContextMenu(response, id);
+      reportDefinitionRequest.report_params.core_params.base_url = 
+        getNotebooksBaseUrlCreate(edit, id, true) + id;
+      // set placeholder time range since notebooks doesn't use it
+      reportDefinitionRequest.report_params.core_params.time_duration = 'PT30M';
     }
   };
 

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -67,7 +67,7 @@ import {
   handleDataToVisualReportSourceChange,
   getNotebooksOptions,
   getNotebooksBaseUrlCreate,
-  getReportSourceFromContextMenu,
+  getReportSourceFromURL,
 } from './report_settings_helpers';
 import { TimeRangeSelect } from './time_range';
 import { converter } from '../utils';
@@ -501,7 +501,7 @@ export function ReportSettings(props: ReportSettingProps) {
  
   const setInContextDefaultConfiguration = (response) => {
     const url = window.location.href;
-    const source = getReportSourceFromContextMenu(url);
+    const source = getReportSourceFromURL(url);
     const id = parseInContextUrl(url, 'id');
     if (source === 'dashboard') {
       setReportSourceId('dashboardReportSource');

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -196,3 +196,8 @@ export const handleDataToVisualReportSourceChange = (
   delete reportDefinitionRequest.report_params.core_params.excel;
   reportDefinitionRequest.report_params.core_params.report_format = 'pdf';
 };
+
+export const getReportSourceFromContextMenu = (url: string) => {
+  const source = url.split('?')[1].match(/previous=(.*):/);
+  return source![1];
+}

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -197,7 +197,7 @@ export const handleDataToVisualReportSourceChange = (
   reportDefinitionRequest.report_params.core_params.report_format = 'pdf';
 };
 
-export const getReportSourceFromContextMenu = (url: string) => {
+export const getReportSourceFromURL = (url: string) => {
   const source = url.split('?')[1].match(/previous=(.*):/);
   return source![1];
 }


### PR DESCRIPTION
### Description
Add logic in reporting to auto-select Notebooks as a report source when directing to `Create report definition` from the Notebooks in-context menu.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
