### PR TITLE
Use output_only Parameter for notebook reports

### DIFF
--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -233,6 +233,7 @@ export function CreateReport(props) {
   ) => {
     const { httpClient } = props;
     //TODO: need better handle
+    console.log('create metadata is', metadata);
     if (
       metadata.trigger.trigger_type === 'On demand' &&
       metadata.trigger.trigger_params !== undefined

--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -233,7 +233,6 @@ export function CreateReport(props) {
   ) => {
     const { httpClient } = props;
     //TODO: need better handle
-    console.log('create metadata is', metadata);
     if (
       metadata.trigger.trigger_type === 'On demand' &&
       metadata.trigger.trigger_params !== undefined

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -119,7 +119,6 @@ export const getNotebooksBaseUrlCreate = (
   let baseUrl;
   if (!fromInContext) {
     baseUrl = location.pathname + location.hash;
-    console.log('baseUrl in notebooks is', baseUrl);
   } else {
     baseUrl = '/app/notebooks-dashboards?view=output_only#/';
   }

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -119,20 +119,21 @@ export const getNotebooksBaseUrlCreate = (
   let baseUrl;
   if (!fromInContext) {
     baseUrl = location.pathname + location.hash;
+    console.log('baseUrl in notebooks is', baseUrl);
   } else {
-    baseUrl = '/app/notebooks-dashboards#/';
+    baseUrl = '/app/notebooks-dashboards?view=output_only#/';
   }
   if (edit) {
     return baseUrl.replace(
       `reports-dashboards#/edit/${editDefinitionId}`,
-      'notebooks-dashboards#/'
+      'notebooks-dashboards?view=output_only#/'
     );
   } else if (fromInContext) {
     return baseUrl;
   }
   return baseUrl.replace(
     'reports-dashboards#/create',
-    'notebooks-dashboards#/'
+    'notebooks-dashboards?view=output_only#/'
   );
 }
 

--- a/dashboards-reports/server/model/backendModel.ts
+++ b/dashboards-reports/server/model/backendModel.ts
@@ -168,5 +168,5 @@ export const URL_PREFIX_DICT = {
   [BACKEND_REPORT_SOURCE.dashboard]: '/app/dashboards#/view/',
   [BACKEND_REPORT_SOURCE.savedSearch]: '/app/discover#/view/',
   [BACKEND_REPORT_SOURCE.visualization]: '/app/visualize#/edit/',
-  [BACKEND_REPORT_SOURCE.notebook]: '/app/notebooks-dashboards#/'
+  [BACKEND_REPORT_SOURCE.notebook]: '/app/notebooks-dashboards?view=output_only#/'
 };

--- a/dashboards-reports/server/utils/validationHelper.ts
+++ b/dashboards-reports/server/utils/validationHelper.ts
@@ -36,12 +36,15 @@ import {
 import { REPORT_TYPE } from '../../server/routes/utils/constants';
 
 export const isValidRelativeUrl = (relativeUrl: string) => {
-  const normalizedRelativeUrl = path.posix.normalize(relativeUrl);
+  let normalizedRelativeUrl = relativeUrl
+  if (!relativeUrl.includes('notebooks-dashboards')) {
+    normalizedRelativeUrl = path.posix.normalize(relativeUrl);
+  }
+  
   // check pattern
   // ODFE pattern: /app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g
   // AES pattern: /_plugin/kibana/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g
   const isValid = regexRelativeUrl.test(normalizedRelativeUrl);
-
   return isValid;
 };
 
@@ -52,7 +55,7 @@ export const isValidRelativeUrl = (relativeUrl: string) => {
 export const regexDuration = /^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
 export const regexEmailAddress = /\S+@\S+\.\S+/;
 export const regexReportName = /^[\w\-\s\(\)\[\]\,\_\-+]+$/;
-export const regexRelativeUrl = /^\/(_plugin\/kibana\/app|app)\/(dashboards|visualize|discover|notebooks-dashboards)(\?security_tenant=.+|)#\/(view\/|edit\/)?[^\/]+$/;
+export const regexRelativeUrl = /^\/(_plugin\/kibana\/app|app)\/(dashboards|visualize|discover|notebooks-dashboards\?view=output_only)(\?security_tenant=.+|)#\/(view\/|edit\/)?[^\/]+$/;
 
 export const validateReport = async (
   client: ILegacyScopedClusterClient,


### PR DESCRIPTION
### Description
Notebooks reports add `?view=output_only` to the base URL to download the output only view for notebook reports. 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
