### PR TITLE
[Query Builder] Correctly handle match phrases when a single value is specified or when the match phrases is negated

### DIFF
--- a/dashboards-reports/server/routes/utils/dataReportHelpers.ts
+++ b/dashboards-reports/server/routes/utils/dataReportHelpers.ts
@@ -111,7 +111,7 @@ export const buildQuery = (report, is_count) => {
                 }
               } else {
                 requestBody.should(
-                  esb.matchPhraseQuery(item.meta.key, item.meta.params.query)
+                  esb.matchPhraseQuery(item.meta.key, item.meta.value)
                 );
               }
               requestBody.minimumShouldMatch(1);

--- a/dashboards-reports/server/routes/utils/dataReportHelpers.ts
+++ b/dashboards-reports/server/routes/utils/dataReportHelpers.ts
@@ -104,17 +104,19 @@ export const buildQuery = (report, is_count) => {
               requestBody.mustNot(esb.existsQuery(item.meta.key));
               break;
             case 'phrases':
+              let negatedBody = esb.boolQuery();
               if (item.meta.value.indexOf(',') > -1) {
                 const valueSplit = item.meta.value.split(', ');
                 for (const [key, incr] of valueSplit.entries()) {
-                  requestBody.should(esb.matchPhraseQuery(item.meta.key, incr));
+                  negatedBody.should(esb.matchPhraseQuery(item.meta.key, incr));
                 }
               } else {
-                requestBody.should(
+                negatedBody.should(
                   esb.matchPhraseQuery(item.meta.key, item.meta.value)
                 );
               }
-              requestBody.minimumShouldMatch(1);
+              negatedBody.minimumShouldMatch(1);
+              requestBody.mustNot(negatedBody);
               break;
           }
           break;

--- a/dashboards-reports/server/routes/utils/dataReportHelpers.ts
+++ b/dashboards-reports/server/routes/utils/dataReportHelpers.ts
@@ -86,7 +86,7 @@ export const buildQuery = (report, is_count) => {
                 }
               } else {
                 requestBody.should(
-                  esb.matchPhraseQuery(item.meta.key, item.meta.params.query)
+                  esb.matchPhraseQuery(item.meta.key, item.meta.value)
                 );
               }
               requestBody.minimumShouldMatch(1);


### PR DESCRIPTION
### Description

#### First issue : the phrases filter is not correctly handled when a single value is specified and trigger an error
When a saved search specify a "is one of" filter - which is stored as a "phrases" filter in the saved search document - and only one value is specified, then the report can not be generated.

The reason is that the current implementation does not use the appropriate field and use a field that does not exist when building the JSON query from the saved search content and triggers a "Query string is required for full text query!" error at the [MonoFieldQueryBase](https://github.com/sudo-suhas/elastic-builder/blob/a9d9096811a239b137bcfc941ab394138d8b44f0/src/queries/full-text-queries/mono-field-query-base.js#L53) level since the current `item.meta.params.query` fied which is used to create the `matchPhraseQuery` does not exist.

For example, the following saved search can not currently be exported :

```
{
  "highlightAll": true,
  "version": true,
  "query": {
    "query": "",
    "language": "kuery"
  },
  "filter": [
    {
      "meta": {
        "type": "phrases",
        "key": "type",
        "value": "woman",
        "params": [
          "woman"
        ],
        "alias": null,
        "negate": false,
        "disabled": false,
        "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
      },
      "query": {
        "bool": {
          "should": [
            {
              "match_phrase": {
                "type": "woman"
              }
            }
          ],
          "minimum_should_match": 1
        }
      },
      "$state": {
        "store": "appState"
      }
    }
  ],
  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index"
}
```

#### Second issue : the negated phrases filter does not exclude the matching documents from the generated report

When a negated phrases filter is applied then it is expected that the generated report will not contains any document matching the negated filter. However, actually the negated phrases filter are not correctly handled and behaves like a "is one of" filter when the report is generated.

For example, currently the following saved search will generate an export containing only "woman" and "man" instead of excluding them.

```
{
  "highlightAll": true,
  "version": true,
  "query": {
    "query": "",
    "language": "kuery"
  },
  "filter": [
    {
      "meta": {
        "type": "phrases",
        "key": "type",
        "value": "woman, man",
        "params": [
          "woman",
          "man"
        ],
        "alias": null,
        "negate": true,
        "disabled": false,
        "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
      },
      "query": {
        "bool": {
          "should": [
            {
              "match_phrase": {
                "type": "woman"
              }
            },
            {
              "match_phrase": {
                "type": "man"
              }
            }
          ],
          "minimum_should_match": 1
        }
      },
      "$state": {
        "store": "appState"
      }
    }
  ],
  "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index"
}
```


### Issues Resolved

I did not open any issue and I no issue has been reported yet.

With this fix it is now possible to generate CSV report when a "is one of" filter specify only one value and the negated phrases filter are correctly handled to exclude the matching results from the generated report

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
