### PR TITLE
Replace osd-version header in context menu

### DIFF
--- a/dashboards-reports/public/components/context_menu/context_menu.js
+++ b/dashboards-reports/public/components/context_menu/context_menu.js
@@ -126,7 +126,7 @@ const generateInContextReport = async (
     {
       headers: {
         'Content-Type': 'application/json',
-        'osd-version': '1.0.0-beta1',
+        'osd-xsrf': 'reporting',
         accept: '*/*',
         'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
         pragma: 'no-cache',
@@ -340,7 +340,7 @@ async function getTenantInfoIfExists() {
   const res = await fetch(`../api/v1/multitenancy/tenant`, {
     headers: {
       'Content-Type': 'application/json',
-      'osd-version': '1.0.0-beta1',
+      'osd-xsrf': 'reporting',
       accept: '*/*',
       'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
       pragma: 'no-cache',


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
Replace `osd-version` header in the context menu request to avoid needing to maintain the version number with the `OpenSearch-Dashboards` core.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
