### PR TITLE
Use commonlyUsedRanges from Kibana Settings instead of a constant value #352

### DIFF
--- a/dashboards-reports/public/application.tsx
+++ b/dashboards-reports/public/application.tsx
@@ -31,8 +31,7 @@ import { AppPluginStartDependencies } from './types';
 import { ReportsDashboardsApp } from './components/app';
 
 export const renderApp = (
-  { notifications, http, chrome }: CoreStart,
-  { navigation }: AppPluginStartDependencies,
+  { notifications, http, chrome, uiSettings }: CoreStart,
   { appBasePath, element }: AppMountParameters
 ) => {
   ReactDOM.render(
@@ -40,7 +39,7 @@ export const renderApp = (
       basename={appBasePath}
       notifications={notifications}
       http={http}
-      navigation={navigation}
+      uiSettings={uiSettings}
       chrome={chrome}
     />,
     element

--- a/dashboards-reports/public/application.tsx
+++ b/dashboards-reports/public/application.tsx
@@ -31,13 +31,12 @@ import { AppPluginStartDependencies } from './types';
 import { ReportsDashboardsApp } from './components/app';
 
 export const renderApp = (
-  { notifications, http, chrome, uiSettings }: CoreStart,
+  { http, chrome, uiSettings }: CoreStart,
   { appBasePath, element }: AppMountParameters
 ) => {
   ReactDOM.render(
     <ReportsDashboardsApp
       basename={appBasePath}
-      notifications={notifications}
       http={http}
       uiSettings={uiSettings}
       chrome={chrome}

--- a/dashboards-reports/public/components/app.tsx
+++ b/dashboards-reports/public/components/app.tsx
@@ -42,7 +42,6 @@ import {
   ChromeBreadcrumb,
   IUiSettingsClient,
 } from '../../../../src/core/public';
-import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
 import { CreateReport } from './report_definitions/create/create_report_definition';
 import { Main } from './main/main';
@@ -60,8 +59,8 @@ interface ReportsDashboardsAppDeps {
   basename: string;
   notifications: CoreStart['notifications'];
   http: CoreStart['http'];
-  navigation: NavigationPublicPluginStart;
   chrome: CoreStart['chrome'];
+  uiSettings: IUiSettingsClient
 }
 
 const styles: CSS.Properties = {
@@ -72,10 +71,9 @@ const styles: CSS.Properties = {
 
 export const ReportsDashboardsApp = ({
   basename,
-  notifications,
   http,
-  navigation,
   chrome,
+  uiSettings
 }: ReportsDashboardsAppDeps) => {
   // Render the application DOM.
   return (
@@ -128,6 +126,7 @@ export const ReportsDashboardsApp = ({
                       <EditReportDefinition
                         title="Edit Report Definition"
                         httpClient={http}
+                        uiSettings={uiSettings}
                         {...props}
                         setBreadcrumbs={chrome.setBreadcrumbs}
                       />

--- a/dashboards-reports/public/components/app.tsx
+++ b/dashboards-reports/public/components/app.tsx
@@ -57,7 +57,6 @@ export interface CoreInterface {
 
 interface ReportsDashboardsAppDeps {
   basename: string;
-  notifications: CoreStart['notifications'];
   http: CoreStart['http'];
   chrome: CoreStart['chrome'];
   uiSettings: IUiSettingsClient

--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -133,6 +133,7 @@ export function CreateReport(props) {
   const [toasts, setToasts] = useState([]);
   const [comingFromError, setComingFromError] = useState(false);
   const [preErrorData, setPreErrorData] = useState({});
+  const {uiSettings} = props;
 
   const [
     showSettingsReportNameError,
@@ -322,6 +323,7 @@ export function CreateReport(props) {
         <EuiSpacer />
         <ReportSettings
           edit={false}
+          uiSettings={uiSettings}
           reportDefinitionRequest={createReportDefinitionRequest}
           httpClientProps={props['httpClient']}
           timeRange={timeRange}

--- a/dashboards-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -51,6 +51,7 @@ export function EditReportDefinition(props) {
   const [toasts, setToasts] = useState([]);
   const [comingFromError, setComingFromError] = useState(false);
   const [preErrorData, setPreErrorData] = useState({});
+  const { uiSettings } = props
 
   const [
     showSettingsReportNameError,
@@ -74,7 +75,7 @@ export function EditReportDefinition(props) {
   ] = useState(false);
   const [showCronError, setShowCronError] = useState(false);
   const [
-    showEmailRecipientsError, 
+    showEmailRecipientsError,
     setShowEmailRecipientsError
   ] = useState(false);
   const [
@@ -309,6 +310,7 @@ export function EditReportDefinition(props) {
         <EuiSpacer />
         <ReportSettings
           edit={true}
+          uiSettings={uiSettings}
           editDefinitionId={reportDefinitionId}
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}

--- a/dashboards-reports/public/components/report_definitions/report_settings/__tests__/report_settings.test.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/__tests__/report_settings.test.tsx
@@ -30,6 +30,7 @@ import { ReportSettings } from '../report_settings';
 import 'babel-polyfill';
 import 'regenerator-runtime';
 import httpClientMock from '../../../../../test/httpMockClient';
+import uiSettingsMock from '../../../../../test/uiSettingsMock';
 import { configure, mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { act } from 'react-dom/test-utils';
@@ -114,6 +115,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -158,6 +160,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -203,6 +206,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -251,6 +255,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -299,6 +304,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -347,6 +353,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -358,7 +365,6 @@ describe('<ReportSettings /> panel', () => {
     expect(container.firstChild).toMatchSnapshot();
     await act(() => promise);
   });
-  
 
   test('dashboard create from in-context', async () => {
     window = Object.create(window);
@@ -403,6 +409,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -461,6 +468,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -521,6 +529,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -569,6 +578,7 @@ describe('<ReportSettings /> panel', () => {
     const component = shallow(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -617,6 +627,7 @@ describe('<ReportSettings /> panel', () => {
     const component = mount(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -635,7 +646,7 @@ describe('<ReportSettings /> panel', () => {
 
     act(() => {
       comboBox.props().onChange([{ value: 'test', label: 'test' }]);
-    }); 
+    });
     component.update();
 
     await act(() => promise);
@@ -674,6 +685,7 @@ describe('<ReportSettings /> panel', () => {
     const component = mount(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -703,6 +715,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -712,6 +725,47 @@ describe('<ReportSettings /> panel', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+    await act(() => promise);
+  });
+
+  test('load commonlyUsedRanges from uiSettings service', async () => {
+    const promise = Promise.resolve();
+    uiSettingsMock.get = jest.fn((key) => [
+      {
+        from: 'now/d',
+        to: 'now/d',
+        display: 'Foo'
+      }
+    ]);
+
+    const component = mount(
+        <ReportSettings
+            edit={false}
+            uiSettings={uiSettingsMock}
+            reportDefinitionRequest={emptyRequest}
+            httpClientProps={httpClientMock}
+            timeRange={timeRange}
+            showSettingsReportNameError={true}
+            showTimeRangeError={true}
+        />
+    );
+    await act(() => promise);
+
+    const superDatePicker =  component.find('EuiSuperDatePicker').at(0);
+
+    expect(superDatePicker.prop('commonlyUsedRanges')).toEqual(
+        [
+          {
+            start: 'now/d',
+            end: 'now/d',
+            label: 'Foo'
+          }
+        ]
+    );
+
+    expect(uiSettingsMock.get.mock.calls.length).toBeGreaterThan(0);
+    expect(uiSettingsMock.get.mock.calls[0][0]).toBe('timepicker:quickRanges');
+
     await act(() => promise);
   });
 });

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -81,6 +81,7 @@ type ReportSettingProps = {
   showSettingsReportSourceError: boolean;
   settingsReportSourceErrorMessage: string;
   showTimeRangeError: boolean;
+  uiSettings: any;
 };
 
 export function ReportSettings(props: ReportSettingProps) {
@@ -95,6 +96,7 @@ export function ReportSettings(props: ReportSettingProps) {
     showSettingsReportSourceError,
     settingsReportSourceErrorMessage,
     showTimeRangeError,
+    uiSettings,
   } = props;
 
   const [reportName, setReportName] = useState('');
@@ -738,6 +740,7 @@ export function ReportSettings(props: ReportSettingProps) {
         {displaySavedSearchSelect}
         <TimeRangeSelect
           timeRange={timeRange}
+          uiSettings={uiSettings}
           reportDefinitionRequest={reportDefinitionRequest}
           edit={edit}
           id={editDefinitionId}

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -76,26 +76,3 @@ export const REPORT_SOURCE_TYPES = {
   visualization: 'Visualization',
   savedSearch: 'Saved search',
 };
-
-export const commonTimeRanges = [
-  {
-    start: 'now/d',
-    end: 'now',
-    label: 'Today so far'
-  },
-  {
-    start: 'now/w',
-    end: 'now',
-    label: 'Week to date'
-  },
-  {
-    start: 'now/M',
-    end: 'now',
-    label: 'Month to date'
-  },
-  {
-    start: 'now/y',
-    end: 'now',
-    label: 'Year to date'
-  }
-]

--- a/dashboards-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -33,7 +33,7 @@ import {
   EuiGlobalToastList,
   EuiSuperDatePicker,
 } from '@elastic/eui';
-import { commonTimeRanges } from './report_settings_constants';
+import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 
 export function TimeRangeSelect(props) {
   const {
@@ -43,6 +43,7 @@ export function TimeRangeSelect(props) {
     id,
     httpClientProps,
     showTimeRangeError,
+    uiSettings
   } = props;
 
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState([]);
@@ -203,6 +204,15 @@ export function TimeRangeSelect(props) {
     setIsLoading(false);
   };
 
+  const commonlyUsedRanges = uiSettings!
+    .get(UI_SETTINGS.TIMEPICKER_QUICK_RANGES)
+    .map(({ from, to, display }: { from: string; to: string; display: string }) => {
+      return {
+        start: from,
+        end: to,
+        label: display,
+      };
+    });
 
   return (
     <div>
@@ -220,7 +230,7 @@ export function TimeRangeSelect(props) {
             end={end}
             onTimeChange={onTimeChange}
             showUpdateButton={false}
-            commonlyUsedRanges={commonTimeRanges}
+            commonlyUsedRanges={commonlyUsedRanges}
           />
         </EuiFormRow>
       </div>

--- a/dashboards-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -33,7 +33,6 @@ import {
   EuiGlobalToastList,
   EuiSuperDatePicker,
 } from '@elastic/eui';
-import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 
 export function TimeRangeSelect(props) {
   const {
@@ -205,7 +204,7 @@ export function TimeRangeSelect(props) {
   };
 
   const commonlyUsedRanges = uiSettings!
-    .get(UI_SETTINGS.TIMEPICKER_QUICK_RANGES)
+    .get('timepicker:quickRanges')
     .map(({ from, to, display }: { from: string; to: string; display: string }) => {
       return {
         start: from,

--- a/dashboards-reports/public/plugin.ts
+++ b/dashboards-reports/public/plugin.ts
@@ -42,7 +42,9 @@ export class ReportsDashboardsPlugin
   implements
     Plugin<
       ReportsDashboardsPluginSetup,
-      ReportsDashboardsPluginStart
+      ReportsDashboardsPluginStart,
+      AppPluginStartDependencies,
+      any
     > {
   public setup(core: CoreSetup): ReportsDashboardsPluginSetup {
     // Register an application into the side navigation menu

--- a/dashboards-reports/public/types.ts
+++ b/dashboards-reports/public/types.ts
@@ -24,7 +24,7 @@
  * permissions and limitations under the License.
  */
 
-import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import { DataPublicPluginStart } from '../../../src/plugins/data/public';
 
 export interface ReportsDashboardsPluginSetup {}
 
@@ -32,5 +32,5 @@ export interface ReportsDashboardsPluginSetup {}
 export interface ReportsDashboardsPluginStart {}
 
 export interface AppPluginStartDependencies {
-  navigation: NavigationPublicPluginStart;
+  data: DataPublicPluginStart;
 }

--- a/dashboards-reports/test/uiSettingsMock.js
+++ b/dashboards-reports/test/uiSettingsMock.js
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const uiSettingsMock = jest.fn();
+
+uiSettingsMock.get = jest.fn((key) => ([]));
+
+export default uiSettingsMock;


### PR DESCRIPTION
### Description
* Add the uiSettings service from Data plugin as dependency
* Removes unused dependencies (notifications and navigation)
* Change time_range component to use commonlyUsedRanges from uiSettings (following default behavior for EuiSuperDatePicker across entire kibana), allowing user to override defaults
* Removed the constant that was used for commonlyUsedRanges
* Implement tests to check if `uiSettings` is being called correctly
* Update tests to add missing new prop `uiSettings`

### Issues Resolved
#41 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
