### PR TITLE
increase Chromium timeout to 100s

### DIFF
--- a/dashboards-reports/public/components/context_menu/context_menu_helpers.js
+++ b/dashboards-reports/public/components/context_menu/context_menu_helpers.js
@@ -158,6 +158,5 @@ export const replaceQueryURL = (pageUrl) => {
     toDateString + '))',
     "'" + toDateFormat.toISOString() + "'))"
   );
-  console.log(`log output queryUrl\n` + queryUrl);
   return queryUrl;
 };

--- a/dashboards-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/dashboards-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -122,7 +122,7 @@ export const createVisualReport = async (
   });
   const page = await browser.newPage();
   page.setDefaultNavigationTimeout(0);
-  page.setDefaultTimeout(60000); // use 60s timeout instead of default 30s
+  page.setDefaultTimeout(100000); // use 100s timeout instead of default 30s
   if (cookie) {
     logger.info('domain enables security, use session cookie to access');
     await page.setCookie(cookie);


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
increase the timeout value to from 60s to largest possible value 100s.
Notice that 2min timout is restricted by Kibana http handler, and if above 100s will produce some auto-retry issues that browser will have a chance not getting the error response.

### Issues Resolved
#48 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
