### PR TITLE
configure index to have default 1 replica and upper bound 2

### DIFF
--- a/reports-scheduler/src/main/resources/report-definitions-settings.yml
+++ b/reports-scheduler/src/main/resources/report-definitions-settings.yml
@@ -28,6 +28,5 @@
 
 # Settings file for the report definitions index
 index:
-  number_of_shards: "1"
-  auto_expand_replicas: "0-1"
-  number_of_replicas: "0"
+  number_of_shards: "1" # The data size is not expected to be big so keeping it 1 shard
+  auto_expand_replicas: "0-2"

--- a/reports-scheduler/src/main/resources/report-instances-settings.yml
+++ b/reports-scheduler/src/main/resources/report-instances-settings.yml
@@ -28,6 +28,5 @@
 
 # Settings file for the report instances index
 index:
-  number_of_shards: "1"
-  auto_expand_replicas: "0-1"
-  number_of_replicas: "0"
+  number_of_shards: "1" # The data size is not expected to be big so keeping it 1 shard
+  auto_expand_replicas: "0-2"


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
configure index to have default 1 replica and upper bound 2
[elasticsearch index dynamic settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#dynamic-index-settings)

### Issues Resolved
#52 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
