### PR TITLE
Revert .opensearch_dashboards index references to .kibana

### DIFF
--- a/dashboards-reports/server/routes/reportSource.ts
+++ b/dashboards-reports/server/routes/reportSource.ts
@@ -54,21 +54,21 @@ export default function (router: IRouter) {
       let responseParams;
       if (request.params.reportSourceType === 'dashboard') {
         const params: RequestParams.Search = {
-          index: '.opensearch_dashboards',
+          index: '.kibana',
           q: 'type:dashboard',
           size: DEFAULT_MAX_SIZE,
         };
         responseParams = params;
       } else if (request.params.reportSourceType === 'visualization') {
         const params: RequestParams.Search = {
-          index: '.opensearch_dashboards',
+          index: '.kibana',
           q: 'type:visualization',
           size: DEFAULT_MAX_SIZE,
         };
         responseParams = params;
       } else if (request.params.reportSourceType === 'search') {
         const params: RequestParams.Search = {
-          index: '.opensearch_dashboards',
+          index: '.kibana',
           q: 'type:search',
           size: DEFAULT_MAX_SIZE,
         };

--- a/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -399,13 +399,13 @@ function mockSavedSearch(columns = '"category", "customer_gender"') {
       "columns": [ ${columns} ],
       "sort": [],
       "version": 1,
-      "opensearchDashboardsSavedObjectMeta": {
-        "searchSourceJSON": "{\\"highlightAll\\":true,\\"version\\":true,\\"query\\":{\\"query\\":\\"\\",\\"language\\":\\"kuery\\"},\\"indexRefName\\":\\"opensearchDashboardsSavedObjectMeta.searchSourceJSON.index\\",\\"filter\\":[]}"
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\\"highlightAll\\":true,\\"version\\":true,\\"query\\":{\\"query\\":\\"\\",\\"language\\":\\"kuery\\"},\\"indexRefName\\":\\"kibanaSavedObjectMeta.searchSourceJSON.index\\",\\"filter\\":[]}"
       }
     },
     "references": [
       {
-        "name": "opensearchDashboardsSavedObjectMeta.searchSourceJSON.index",
+        "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
         "type": "index-pattern",
         "id": "ff959d40-b880-11e8-a6d9-e546fe2bba5f"
       }

--- a/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -89,7 +89,7 @@ async function populateMetaData(
   // Get saved search info
   let resIndexPattern: any = {};
   const ssParams = {
-    index: '.opensearch_dashboards',
+    index: '.kibana',
     id: 'search:' + metaData.saved_search_id,
   };
   const ssInfos = await callCluster(client, 'get', ssParams, isScheduledTask);
@@ -97,7 +97,7 @@ async function populateMetaData(
   metaData.sorting = ssInfos._source.search.sort;
   metaData.type = ssInfos._source.type;
   metaData.filters =
-    ssInfos._source.search.opensearchDashboardsSavedObjectMeta.searchSourceJSON;
+    ssInfos._source.search.kibanaSavedObjectMeta.searchSourceJSON;
 
   // Get the list of selected columns in the saved search.Otherwise select all the fields under the _source
   await getSelectedFields(ssInfos._source.search.columns);
@@ -110,7 +110,7 @@ async function populateMetaData(
         client,
         'get',
         {
-          index: '.opensearch_dashboards',
+          index: '.kibana',
           id: 'index-pattern:' + item.id,
         },
         isScheduledTask

--- a/dashboards-reports/server/utils/validationHelper.ts
+++ b/dashboards-reports/server/utils/validationHelper.ts
@@ -137,7 +137,7 @@ const validateSavedObject = async (
   else {
     savedObjectId = `${getType(source)}:${getId(url)}`;
     const params: RequestParams.Exists = {
-      index: '.opensearch_dashboards',
+      index: '.kibana',
       id: savedObjectId,
     };
     exist = await client.callAsCurrentUser('exists', params);  


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
Revert `.opensearch_dashboards` index changes to `.kibana` 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
