### PR TITLE
Change Delivery Request Body for Notifications

### DIFF
--- a/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -317,8 +317,8 @@ export function ReportDefinitionDetails(props) {
     const {
       configIds: configIds,
       title: title,
-      text_description: textDescription,
-      html_description: htmlDescription
+      textDescription: textDescription,
+      htmlDescription: htmlDescription
     } = delivery;
     const {
       core_params: {

--- a/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -315,8 +315,10 @@ export function ReportDefinitionDetails(props) {
       trigger_params: triggerParams,
     } = trigger;
     const {
-      delivery_type: deliveryType,
-      delivery_params: deliveryParams,
+      configIds: configIds,
+      title: title,
+      text_description: textDescription,
+      html_description: htmlDescription
     } = delivery;
     const {
       core_params: {
@@ -357,17 +359,11 @@ export function ReportDefinitionDetails(props) {
       scheduleDetails: triggerParams
         ? humanReadableScheduleDetails(data.report_definition.trigger)
         : `\u2014`,
-      channel: deliveryType,
       status: reportDefinition.status,
-      opensearchDashboardsRecipients: deliveryParams.opensearch_dashboards_recipients
-        ? deliveryParams.opensearch_dashboards_recipients
-        : `\u2014`,
-      emailRecipients:
-        deliveryType === 'Channel' ? deliveryParams.recipients : `\u2014`,
-      emailSubject:
-        deliveryType === 'Channel' ? deliveryParams.title : `\u2014`,
-      emailBody:
-        deliveryType === 'Channel' ? deliveryParams.textDescription : `\u2014`,
+      configIds: configIds,
+      title: title,
+      textDescription: textDescription,
+      htmlDescription: htmlDescription
     };
     return reportDefinitionDetails;
   };

--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -236,7 +236,6 @@ export function CreateReport(props) {
     timeRange: timeRangeParams
   ) => {
     const { httpClient } = props;
-    console.log('metadata is', metadata);
     //TODO: need better handle
     if (
       metadata.trigger.trigger_type === 'On demand' &&

--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -74,8 +74,8 @@ interface triggerType {
 interface deliveryType {
   configIds: Array<string>;
   title: string;
-  text_description: string;
-  html_description: string;
+  textDescription: string;
+  htmlDescription: string;
 }
 
 export interface TriggerParamsType {
@@ -126,8 +126,8 @@ export function CreateReport(props) {
     delivery: {
       configIds: [],
       title: '',
-      text_description: '',
-      html_description: ''
+      textDescription: '',
+      htmlDescription: ''
     },
     trigger: {
       trigger_type: '',

--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -72,8 +72,10 @@ interface triggerType {
 }
 
 interface deliveryType {
-  delivery_type: string;
-  delivery_params: any;
+  configIds: Array<string>;
+  title: string;
+  text_description: string;
+  html_description: string;
 }
 
 export interface TriggerParamsType {
@@ -122,8 +124,10 @@ export function CreateReport(props) {
       },
     },
     delivery: {
-      delivery_type: '',
-      delivery_params: {},
+      configIds: [],
+      title: '',
+      text_description: '',
+      html_description: ''
     },
     trigger: {
       trigger_type: '',
@@ -232,6 +236,7 @@ export function CreateReport(props) {
     timeRange: timeRangeParams
   ) => {
     const { httpClient } = props;
+    console.log('metadata is', metadata);
     //TODO: need better handle
     if (
       metadata.trigger.trigger_type === 'On demand' &&

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -77,8 +77,10 @@ export function ReportDelivery(props: ReportDeliveryProps) {
 
   const defaultCreateDeliveryParams = () => {
     reportDefinitionRequest.delivery = {
-      delivery_type: DELIVERY_TYPE_OPTIONS[0].id,
-      delivery_params: { opensearch_dashboards_recipients: [] },
+      configIds: [],
+      title: '',
+      text_description: '',
+      html_description: ''
     };
   };
 

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -79,8 +79,8 @@ export function ReportDelivery(props: ReportDeliveryProps) {
     reportDefinitionRequest.delivery = {
       configIds: [],
       title: '',
-      text_description: '',
-      html_description: ''
+      textDescription: '',
+      htmlDescription: ''
     };
   };
 

--- a/dashboards-reports/server/model/backendModel.ts
+++ b/dashboards-reports/server/model/backendModel.ts
@@ -92,13 +92,10 @@ export type IntervalType = {
 };
 
 export type DeliveryType = {
-  // recipients: string[];
   configIds: string[];
-  // deliveryFormat: BACKEND_DELIVERY_FORMAT;
   title: string;
-  textDescription: string;
-  htmlDescription?: string;
-  // channelIds?: string[];
+  text_description: string;
+  html_description?: string;
 };
 
 export enum BACKEND_DELIVERY_FORMAT {

--- a/dashboards-reports/server/model/backendModel.ts
+++ b/dashboards-reports/server/model/backendModel.ts
@@ -94,8 +94,8 @@ export type IntervalType = {
 export type DeliveryType = {
   configIds: string[];
   title: string;
-  text_description: string;
-  html_description?: string;
+  textDescription: string;
+  htmlDescription?: string;
 };
 
 export enum BACKEND_DELIVERY_FORMAT {

--- a/dashboards-reports/server/model/backendModel.ts
+++ b/dashboards-reports/server/model/backendModel.ts
@@ -92,12 +92,13 @@ export type IntervalType = {
 };
 
 export type DeliveryType = {
-  recipients: string[];
-  deliveryFormat: BACKEND_DELIVERY_FORMAT;
+  // recipients: string[];
+  configIds: string[];
+  // deliveryFormat: BACKEND_DELIVERY_FORMAT;
   title: string;
   textDescription: string;
   htmlDescription?: string;
-  channelIds?: string[];
+  // channelIds?: string[];
 };
 
 export enum BACKEND_DELIVERY_FORMAT {

--- a/dashboards-reports/server/model/index.ts
+++ b/dashboards-reports/server/model/index.ts
@@ -187,7 +187,7 @@ export const triggerSchema = schema.object({
 });
 
 export const deliverySchema = schema.object({
-  configIds: schema.maybe(schema.arrayOf(schema.string())),
+  configIds: schema.arrayOf(schema.string()),
   title: schema.string(),
   textDescription: schema.string(),
   htmlDescription: schema.string()

--- a/dashboards-reports/server/model/index.ts
+++ b/dashboards-reports/server/model/index.ts
@@ -189,8 +189,8 @@ export const triggerSchema = schema.object({
 export const deliverySchema = schema.object({
   configIds: schema.maybe(schema.arrayOf(schema.string())),
   title: schema.string(),
-  text_description: schema.string(),
-  html_description: schema.string()
+  textDescription: schema.string(),
+  htmlDescription: schema.string()
 });
 
 export const reportParamsSchema = schema.object({

--- a/dashboards-reports/server/model/index.ts
+++ b/dashboards-reports/server/model/index.ts
@@ -187,16 +187,10 @@ export const triggerSchema = schema.object({
 });
 
 export const deliverySchema = schema.object({
-  delivery_type: schema.oneOf([
-    schema.literal(DELIVERY_TYPE.opensearchDashboardsUser),
-    schema.literal(DELIVERY_TYPE.channel),
-  ]),
-  delivery_params: schema.conditional(
-    schema.siblingRef('delivery_type'),
-    DELIVERY_TYPE.opensearchDashboardsUser,
-    opensearchDashboardsUserSchema,
-    channelSchema
-  ),
+  configIds: schema.maybe(schema.arrayOf(schema.string())),
+  title: schema.string(),
+  text_description: schema.string(),
+  html_description: schema.string()
 });
 
 export const reportParamsSchema = schema.object({

--- a/dashboards-reports/server/routes/reportDefinition.ts
+++ b/dashboards-reports/server/routes/reportDefinition.ts
@@ -181,13 +181,11 @@ export default function (router: IRouter, accessInfo: AccessInfoType) {
         fromIndex: number;
         maxItems: number;
       };
-
       try {
         // @ts-ignore
         const opensearchReportsClient: ILegacyScopedClusterClient = context.reporting_plugin.opensearchReportsClient.asScoped(
           request
         );
-
         const opensearchResp = await opensearchReportsClient.callAsCurrentUser(
           'opensearch_reports.getReportDefinitions',
           {
@@ -195,12 +193,10 @@ export default function (router: IRouter, accessInfo: AccessInfoType) {
             maxItems: maxItems || DEFAULT_MAX_SIZE,
           }
         );
-
         const reportDefinitionsList = backendToUiReportDefinitionsList(
           opensearchResp.reportDefinitionDetailsList,
           basePath
         );
-
         return response.ok({
           body: {
             data: reportDefinitionsList,

--- a/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -53,8 +53,8 @@ const input = {
     delivery: {
       configIds: [],
       title: 'title',
-      text_description: 'text description',
-      html_description: 'html description'
+      textDescription: 'text description',
+      htmlDescription: 'html description'
     },
     trigger: {
       trigger_type: 'On demand',

--- a/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -51,10 +51,10 @@ const input = {
       },
     },
     delivery: {
-      delivery_type: 'OpenSearch Dashboards user',
-      delivery_params: {
-        opensearch_dashboards_recipients: [],
-      },
+      configIds: [],
+      title: 'title',
+      text_description: 'text description',
+      html_description: 'html description'
     },
     trigger: {
       trigger_type: 'On demand',

--- a/dashboards-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
+++ b/dashboards-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
@@ -59,10 +59,10 @@ const input = {
       },
     },
     delivery: {
-      delivery_type: 'OpenSearch Dashboards user',
-      delivery_params: {
-        opensearch_dashboards_recipients: [],
-      },
+      configIds: [],
+      title: 'title',
+      text_description: 'text description',
+      html_description: 'html description'
     },
     trigger: {
       trigger_type: 'On demand',

--- a/dashboards-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
+++ b/dashboards-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
@@ -61,8 +61,8 @@ const input = {
     delivery: {
       configIds: [],
       title: 'title',
-      text_description: 'text description',
-      html_description: 'html description'
+      textDescription: 'text description',
+      htmlDescription: 'html description'
     },
     trigger: {
       trigger_type: 'On demand',

--- a/dashboards-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
+++ b/dashboards-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
@@ -73,8 +73,8 @@ const input: BackendReportInstanceType = {
       },
       delivery: {
         title: 'test email subject',
-        text_description: '- test\n- optional\n- message',
-        html_description:
+        textDescription: '- test\n- optional\n- message',
+        htmlDescription:
           '<ul>\n<li>test</li>\n<li>optional</li>\n<li>message</li>\n</ul>',
         configIds: [],
       },
@@ -128,8 +128,8 @@ const output = {
     },
     delivery: {
       title: 'test email subject',
-      text_description: '- test\n- optional\n- message',
-      html_description:
+      textDescription: '- test\n- optional\n- message',
+      htmlDescription:
         '<ul>\n<li>test</li>\n<li>optional</li>\n<li>message</li>\n</ul>',
       configIds: [],
     },

--- a/dashboards-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
+++ b/dashboards-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
@@ -72,13 +72,11 @@ const input: BackendReportInstanceType = {
         },
       },
       delivery: {
-        recipients: ['szhongna@amazon.com'],
-        deliveryFormat: BACKEND_DELIVERY_FORMAT.embedded,
         title: 'test email subject',
-        textDescription: '- test\n- optional\n- message',
-        htmlDescription:
+        text_description: '- test\n- optional\n- message',
+        html_description:
           '<ul>\n<li>test</li>\n<li>optional</li>\n<li>message</li>\n</ul>',
-        channelIds: [],
+        configIds: [],
       },
     },
   },
@@ -129,15 +127,11 @@ const output = {
       },
     },
     delivery: {
-      delivery_type: 'Channel',
-      delivery_params: {
-        recipients: ['szhongna@amazon.com'],
-        title: 'test email subject',
-        textDescription: '- test\n- optional\n- message',
-        htmlDescription:
-          '<ul>\n<li>test</li>\n<li>optional</li>\n<li>message</li>\n</ul>',
-        channelIds: [],
-      },
+      title: 'test email subject',
+      text_description: '- test\n- optional\n- message',
+      html_description:
+        '<ul>\n<li>test</li>\n<li>optional</li>\n<li>message</li>\n</ul>',
+      configIds: [],
     },
     time_created: 1605056426053,
     last_updated: 1605056426053,

--- a/dashboards-reports/server/routes/utils/converters/backendToUi.ts
+++ b/dashboards-reports/server/routes/utils/converters/backendToUi.ts
@@ -136,10 +136,9 @@ export const backendToUiReportDefinition = (
       delivery,
     },
   } = backendReportDefinitionDetails;
-
+  
   const baseUrl = getBaseUrl(sourceType, sourceId);
   const reportSource = getUiReportSource(sourceType);
-
   let uiReportDefinition: ReportDefinitionSchemaType = {
     report_params: {
       report_name: name,
@@ -175,7 +174,6 @@ export const backendToUiReportDefinition = (
     last_updated: lastUpdatedTimeMs,
     status: getUiReportDefinitionStatus(isEnabled),
   };
-
   // validate to assign default values to some fields for UI model
   uiReportDefinition = reportDefinitionSchema.validate(uiReportDefinition);
   uiReportDefinition.report_params.core_params.base_url =
@@ -370,20 +368,17 @@ const getUiDeliveryParams = (
   delivery: DeliveryType | undefined
 ): DeliverySchemaType => {
   const opensearchDashboardsUserDeliveryParams = {
-    delivery_type: DELIVERY_TYPE.opensearchDashboardsUser,
-    delivery_params: {
-      opensearch_dashboards_recipients: [],
-    },
+    configIds: [],
+    title: '',
+    text_description: '',
+    html_description: ''
   };
 
   let params: any;
   if (delivery) {
-    const { deliveryFormat, ...rest } = delivery;
+    const { ...rest } = delivery;
     params = {
-      delivery_type: DELIVERY_TYPE.channel,
-      delivery_params: {
-        ...rest,
-      },
+      ...rest
     };
   } else {
     params = opensearchDashboardsUserDeliveryParams;

--- a/dashboards-reports/server/routes/utils/converters/backendToUi.ts
+++ b/dashboards-reports/server/routes/utils/converters/backendToUi.ts
@@ -136,7 +136,7 @@ export const backendToUiReportDefinition = (
       delivery,
     },
   } = backendReportDefinitionDetails;
-  
+
   const baseUrl = getBaseUrl(sourceType, sourceId);
   const reportSource = getUiReportSource(sourceType);
   let uiReportDefinition: ReportDefinitionSchemaType = {
@@ -370,8 +370,8 @@ const getUiDeliveryParams = (
   const opensearchDashboardsUserDeliveryParams = {
     configIds: [],
     title: '',
-    text_description: '',
-    html_description: ''
+    textDescription: '',
+    htmlDescription: ''
   };
 
   let params: any;

--- a/dashboards-reports/server/utils/__tests__/validationHelper.test.ts
+++ b/dashboards-reports/server/utils/__tests__/validationHelper.test.ts
@@ -51,8 +51,8 @@ const createReportDefinitionInput: ReportDefinitionSchemaType = {
   delivery: {
     configIds: [],
     title: 'title',
-    text_description: 'text description',
-    html_description: 'html description'
+    textDescription: 'text description',
+    htmlDescription: 'html description'
   },
   trigger: {
     trigger_type: TRIGGER_TYPE.onDemand,
@@ -82,8 +82,8 @@ const createReportDefinitionNotebookInput: ReportDefinitionSchemaType = {
   delivery: {
     configIds: [],
     title: 'title',
-    text_description: 'text description',
-    html_description: 'html description'
+    textDescription: 'text description',
+    htmlDescription: 'html description'
   },
   trigger: {
     trigger_type: TRIGGER_TYPE.onDemand,

--- a/dashboards-reports/server/utils/__tests__/validationHelper.test.ts
+++ b/dashboards-reports/server/utils/__tests__/validationHelper.test.ts
@@ -49,10 +49,10 @@ const createReportDefinitionInput: ReportDefinitionSchemaType = {
     },
   },
   delivery: {
-    delivery_type: DELIVERY_TYPE.opensearchDashboardsUser,
-    delivery_params: {
-      opensearch_dashboards_recipients: [],
-    },
+    configIds: [],
+    title: 'title',
+    text_description: 'text description',
+    html_description: 'html description'
   },
   trigger: {
     trigger_type: TRIGGER_TYPE.onDemand,
@@ -80,10 +80,10 @@ const createReportDefinitionNotebookInput: ReportDefinitionSchemaType = {
     },
   },
   delivery: {
-    delivery_type: DELIVERY_TYPE.opensearchDashboardsUser,
-    delivery_params: {
-      opensearch_dashboards_recipients: [],
-    },
+    configIds: [],
+    title: 'title',
+    text_description: 'text description',
+    html_description: 'html description'
   },
   trigger: {
     trigger_type: TRIGGER_TYPE.onDemand,

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinition.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinition.kt
@@ -381,15 +381,12 @@ internal data class ReportDefinition(
      * Report definition delivery data class
      */
     internal data class Delivery(
-        val recipients: List<String>,
-        val deliveryFormat: DeliveryFormat,
         val title: String,
         val textDescription: String,
         val htmlDescription: String?,
-        val channelIds: List<String>
+        val configIds: List<String>
     ) : ToXContentObject {
         internal companion object {
-            private const val RECIPIENTS_TAG = "recipients"
             private const val DELIVERY_FORMAT_TAG = "deliveryFormat"
             private const val TITLE_TAG = "title"
             private const val TEXT_DESCRIPTION_TAG = "textDescription"
@@ -403,34 +400,29 @@ internal data class ReportDefinition(
              */
             fun parse(parser: XContentParser): Delivery {
                 var recipients: List<String> = listOf()
-                var deliveryFormat: DeliveryFormat? = null
                 var title: String? = null
                 var textDescription: String? = null
                 var htmlDescription: String? = null
-                var channelIds: List<String> = listOf()
+                var configIds: List<String> = listOf()
                 XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser)
                 while (XContentParser.Token.END_OBJECT != parser.nextToken()) {
                     val fieldName = parser.currentName()
                     parser.nextToken()
                     when (fieldName) {
-                        RECIPIENTS_TAG -> recipients = parser.stringList()
-                        DELIVERY_FORMAT_TAG -> deliveryFormat = DeliveryFormat.valueOf(parser.text())
                         TITLE_TAG -> title = parser.text()
                         TEXT_DESCRIPTION_TAG -> textDescription = parser.text()
                         HTML_DESCRIPTION_TAG -> htmlDescription = parser.textOrNull()
-                        CHANNEL_IDS_TAG -> channelIds = parser.stringList()
+                        CHANNEL_IDS_TAG -> configIds = parser.stringList()
                         else -> log.info("$LOG_PREFIX: Delivery Unknown field $fieldName")
                     }
                 }
-                deliveryFormat ?: throw IllegalArgumentException("$DELIVERY_FORMAT_TAG field absent")
                 title ?: throw IllegalArgumentException("$TITLE_TAG field absent")
                 textDescription ?: throw IllegalArgumentException("$TEXT_DESCRIPTION_TAG field absent")
-                return Delivery(recipients,
-                    deliveryFormat,
+                return Delivery(
                     title,
                     textDescription,
                     htmlDescription,
-                    channelIds)
+                    configIds)
             }
         }
 
@@ -440,14 +432,12 @@ internal data class ReportDefinition(
         override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
             builder!!
             builder.startObject()
-                .field(RECIPIENTS_TAG, recipients)
-                .field(DELIVERY_FORMAT_TAG, deliveryFormat)
                 .field(TITLE_TAG, title)
                 .field(TEXT_DESCRIPTION_TAG, textDescription)
             if (htmlDescription != null) {
                 builder.field(HTML_DESCRIPTION_TAG, htmlDescription)
             }
-            builder.field(CHANNEL_IDS_TAG, channelIds)
+            builder.field(CHANNEL_IDS_TAG, configIds)
             builder.endObject()
             return builder
         }


### PR DESCRIPTION
### Description
* Change the request body for report definitions for Notifications integration in OpenSearch and OpenSearch Dashboards
Sample request body:
```
"delivery": {
  confidIds: ["id1", "id2"],
  textDescription: "textDescription",
  htmlDescription: "htmlDescription",
  title: "title"
}
```
* Update references in Report definition details to prevent error toast on visiting page (further UI changes to come)
* Update all test cases

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
