### PR TITLE
Connect Notifications APIs to Reporting

### DIFF
--- a/dashboards-reports/common/index.ts
+++ b/dashboards-reports/common/index.ts
@@ -40,11 +40,11 @@ export const OPENSEARCH_REPORTS_API = {
   POLL_REPORT_INSTANCE: `${BASE_REPORTS_URI}/poll_instance`,
 };
 
-const NOTIFICATIONS_API_PREFIX = '/api/reporting_notifications';
-export const NOTIFICATIONS_DASHBOARDS_API = Object.freeze({
-  GET_CONFIGS: `${NOTIFICATIONS_API_PREFIX}/get_configs`,
-  GET_EVENT: `${NOTIFICATIONS_API_PREFIX}/get_event`,
-  SEND_TEST_MESSAGE: `${NOTIFICATIONS_API_PREFIX}/test_message`
+const REPORTING_NOTIFICATIONS_API_PREFIX = '/api/reporting_notifications';
+export const REPORTING_NOTIFICATIONS_DASHBOARDS_API = Object.freeze({
+  GET_CONFIGS: `${REPORTING_NOTIFICATIONS_API_PREFIX}/get_configs`,
+  GET_EVENT: `${REPORTING_NOTIFICATIONS_API_PREFIX}/get_event`,
+  SEND_TEST_MESSAGE: `${REPORTING_NOTIFICATIONS_API_PREFIX}/test_message`
 });
 
 const NOTIFICATIONS_API_BASE_PATH = '/_plugins/_notifications';

--- a/dashboards-reports/common/index.ts
+++ b/dashboards-reports/common/index.ts
@@ -39,3 +39,15 @@ export const OPENSEARCH_REPORTS_API = {
   LIST_REPORT_DEFINITIONS: `${BASE_REPORTS_URI}/definitions`,
   POLL_REPORT_INSTANCE: `${BASE_REPORTS_URI}/poll_instance`,
 };
+
+const NOTIFICATIONS_DASHBOARDS_BASE_PATH = '/api/reporting_notifications';
+export const NOTIFICATIONS_DASHBOARDS_API = Object.freeze({
+  GET_CONFIGS: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/get_configs`,
+  SEND_TEST_MESSAGE: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/test_message`
+});
+
+const NOTIFICATIONS_API_BASE_PATH = '/_plugins/_notifications';
+export const NOTIFICATIONS_API = Object.freeze({
+  CONFIGS: `${NOTIFICATIONS_API_BASE_PATH}/configs`,
+  TEST_MESSAGE: `${NOTIFICATIONS_API_BASE_PATH}/feature/test`
+});

--- a/dashboards-reports/common/index.ts
+++ b/dashboards-reports/common/index.ts
@@ -43,11 +43,13 @@ export const OPENSEARCH_REPORTS_API = {
 const NOTIFICATIONS_DASHBOARDS_BASE_PATH = '/api/reporting_notifications';
 export const NOTIFICATIONS_DASHBOARDS_API = Object.freeze({
   GET_CONFIGS: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/get_configs`,
+  GET_EVENT: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/get_event`,
   SEND_TEST_MESSAGE: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/test_message`
 });
 
 const NOTIFICATIONS_API_BASE_PATH = '/_plugins/_notifications';
 export const NOTIFICATIONS_API = Object.freeze({
   CONFIGS: `${NOTIFICATIONS_API_BASE_PATH}/configs`,
+  EVENTS: `${NOTIFICATIONS_API_BASE_PATH}/events`,
   TEST_MESSAGE: `${NOTIFICATIONS_API_BASE_PATH}/feature/test`
 });

--- a/dashboards-reports/common/index.ts
+++ b/dashboards-reports/common/index.ts
@@ -40,11 +40,11 @@ export const OPENSEARCH_REPORTS_API = {
   POLL_REPORT_INSTANCE: `${BASE_REPORTS_URI}/poll_instance`,
 };
 
-const NOTIFICATIONS_DASHBOARDS_BASE_PATH = '/api/reporting_notifications';
+const NOTIFICATIONS_API_PREFIX = '/api/reporting_notifications';
 export const NOTIFICATIONS_DASHBOARDS_API = Object.freeze({
-  GET_CONFIGS: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/get_configs`,
-  GET_EVENT: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/get_event`,
-  SEND_TEST_MESSAGE: `${NOTIFICATIONS_DASHBOARDS_BASE_PATH}/test_message`
+  GET_CONFIGS: `${NOTIFICATIONS_API_PREFIX}/get_configs`,
+  GET_EVENT: `${NOTIFICATIONS_API_PREFIX}/get_event`,
+  SEND_TEST_MESSAGE: `${NOTIFICATIONS_API_PREFIX}/test_message`
 });
 
 const NOTIFICATIONS_API_BASE_PATH = '/_plugins/_notifications';

--- a/dashboards-reports/public/components/main/main_utils.tsx
+++ b/dashboards-reports/public/components/main/main_utils.tsx
@@ -34,6 +34,7 @@ export const displayDeliveryChannels = (configIds: Array<string>, channels: Arra
     for (let j = 0; j < channels.length; ++j) {
       if (configIds[i] === channels[j].id) {
         displayChannels.push(channels[j].label);
+        break;
       }
     }
   }
@@ -44,13 +45,11 @@ export const getAvailableNotificationsChannels = (configList: any) => {
   let availableChannels = [];
   for (let i = 0; i < configList.length; ++i) {
     let channelEntry = {};
-    if (configList[i].config.feature_list.includes('reports')) {
-      channelEntry = {
-        label: configList[i].config.name,
-        id: configList[i].config_id
-      }
-      availableChannels.push(channelEntry);
+    channelEntry = {
+      label: configList[i].config.name,
+      id: configList[i].config_id
     }
+    availableChannels.push(channelEntry);
   }
   return availableChannels;
 }

--- a/dashboards-reports/public/components/main/main_utils.tsx
+++ b/dashboards-reports/public/components/main/main_utils.tsx
@@ -27,18 +27,32 @@
 import 'babel-polyfill';
 import { i18n } from '@osd/i18n';
 import { HttpFetchOptions, HttpSetup } from '../../../../../src/core/public';
-import { placeholderChannels } from '../report_definitions/delivery/delivery_constants';
 
-export const displayDeliveryChannels = (configIds: Array<string>) => {
+export const displayDeliveryChannels = (configIds: Array<string>, channels: Array<{label: string, id: string}>) => {
   let displayChannels = [];
   for (let i = 0; i < configIds.length; ++i) {
-    for (let j = 0; j < placeholderChannels.length; ++j) {
-      if (configIds[i] === placeholderChannels[j].id) {
-        displayChannels.push(placeholderChannels[i].label);
+    for (let j = 0; j < channels.length; ++j) {
+      if (configIds[i] === channels[j].id) {
+        displayChannels.push(channels[j].label);
       }
     }
   }
   return displayChannels.toString();
+}
+
+export const getAvailableNotificationsChannels = (configList: any) => {
+  let availableChannels = [];
+  for (let i = 0; i < configList.length; ++i) {
+    let channelEntry = {};
+    if (configList[i].config.feature_list.includes('reports')) {
+      channelEntry = {
+        label: configList[i].config.name,
+        id: configList[i].config_id
+      }
+      availableChannels.push(channelEntry);
+    }
+  }
+  return availableChannels;
 }
 
 type fileFormatsOptions = {

--- a/dashboards-reports/public/components/main/report_definition_details/__tests__/report_definition_details.test.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/__tests__/report_definition_details.test.tsx
@@ -83,6 +83,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     const { container } = render(
@@ -137,6 +138,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     const { container } = render(
@@ -191,6 +193,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     const { container } = render(
@@ -234,6 +237,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     const component = mount(
@@ -292,6 +296,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     const component = mount(
@@ -351,6 +356,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     httpClientMock.put = jest.fn().mockResolvedValue({});
@@ -412,6 +418,7 @@ describe('<ReportDefinitionDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      config_list: []
     });
 
     httpClientMock.put = jest.fn().mockResolvedValue({});

--- a/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -410,18 +410,6 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
     return scheduleDetails;
   };
 
-  // const displayDeliveryChannels = (configIds: Array<string>) => {
-  //   let displayChannels = [];
-  //   for (let i = 0; i < configIds.length; ++i) {
-  //     for (let j = 0; j < placeholderChannels.length; ++j) {
-  //       if (configIds[i] === placeholderChannels[j].id) {
-  //         displayChannels.push(placeholderChannels[i].label);
-  //       }
-  //     }
-  //   }
-  //   return displayChannels.toString();
-  // }
-
   const getReportDefinitionDetailsMetadata = (data: ReportDefinitionSchemaType) : ReportDefinitionDetails => {
     const reportDefinition: ReportDefinitionSchemaType = data;
     const {

--- a/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -63,7 +63,7 @@ import {
   permissionsMissingActions,
 } from '../../utils/utils';
 import { GenerateReportLoadingModal } from '../loading_modal';
-import { getChannelsQueryObject, placeholderChannels } from '../../report_definitions/delivery/delivery_constants';
+import { getChannelsQueryObject } from '../../report_definitions/delivery/delivery_constants';
 
 const ON_DEMAND = 'On demand';
 
@@ -114,6 +114,7 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
   const [toasts, setToasts] = useState([]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showLoading, setShowLoading] = useState(false);
+  const [channels, setChannels] = useState<Array<{ label: string; id: string; }>>([]);
   const reportDefinitionId = props.match['params']['reportDefinitionId'];
 
   const handleLoading = (e: boolean | ((prevState: boolean) => boolean)) => {
@@ -411,7 +412,10 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
     return scheduleDetails;
   };
 
-  const getReportDefinitionDetailsMetadata = (data: ReportDefinitionSchemaType, availableChannels) : ReportDefinitionDetails => {
+  const getReportDefinitionDetailsMetadata = (
+    data: ReportDefinitionSchemaType, 
+    availableChannels: Array<{ label: string; id: string; }>
+  ) : ReportDefinitionDetails => {
     const reportDefinition: ReportDefinitionSchemaType = data;
     const {
       report_params: reportParams,
@@ -485,11 +489,12 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
   useEffect(() => {
     const { httpClient } = props;
     httpClient
-    .get('../api/notifications/get_configs', {
+    .get('../api/reporting_notifications/get_configs', {
       query: getChannelsQueryObject
     })
     .then(async (response: any) => {
       let availableChannels = getAvailableNotificationsChannels(response.config_list);
+      setChannels(availableChannels);
       return availableChannels;
     })
     .then((availableChannels: any) => {
@@ -583,7 +588,7 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
         updatedRawResponse.report_definition = updatedReportDefinition;
         handleReportDefinitionRawResponse(updatedRawResponse);
         setReportDefinitionDetails(
-          getReportDefinitionDetailsMetadata(updatedReportDefinition)
+          getReportDefinitionDetailsMetadata(updatedReportDefinition, channels)
         );
         if (statusChange === 'Enable') {
           handleSuccessChangingScheduleStatusToast('enable');

--- a/dashboards-reports/public/components/main/report_details/__tests__/__snapshots__/report_details.test.tsx.snap
+++ b/dashboards-reports/public/components/main/report_details/__tests__/__snapshots__/report_details.test.tsx.snap
@@ -32,7 +32,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             >
               <h2
                 class="euiTitle euiTitle--medium"
-              />
+              >
+                test create report definition trigger
+              </h2>
             </div>
           </div>
         </div>
@@ -64,7 +66,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              test create report definition trigger
+            </dd>
           </dl>
         </div>
         <div
@@ -80,7 +84,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -96,7 +102,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -112,7 +120,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
       </div>
@@ -138,11 +148,11 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             >
               <a
                 class="euiLink euiLink--primary"
-                href=""
+                href="http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                
+                Dashboard
               </a>
             </dd>
           </dl>
@@ -160,7 +170,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              Invalid Date -&gt; 10/23/2020, 1:53:35 PM
+            </dd>
           </dl>
         </div>
         <div
@@ -236,7 +248,11 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
         <div
@@ -252,7 +268,11 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
         <div
@@ -303,7 +323,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              Schedule
+            </dd>
           </dl>
         </div>
         <div
@@ -319,7 +341,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              Recurring
+            </dd>
           </dl>
         </div>
         <div
@@ -335,7 +359,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -380,7 +406,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -396,7 +424,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -412,7 +442,9 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -428,7 +460,11 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
       </div>
@@ -437,65 +473,7 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
       aria-live="polite"
       class="euiGlobalToastList euiGlobalToastList--right"
       role="region"
-    >
-      <div
-        class="euiToast euiToast--danger euiGlobalToastListItem"
-        id="reportDetailsErrorToast"
-      >
-        <p
-          class="euiScreenReaderOnly"
-        >
-          A new notification appears
-        </p>
-        <div
-          aria-label="Notification"
-          class="euiToastHeader"
-          data-test-subj="euiToastHeader"
-        >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium euiToastHeader__icon"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.59 10.059L7.35 5.18h1.3L8.4 10.06h-.81zm.394 1.901a.61.61 0 01-.448-.186.606.606 0 01-.186-.444c0-.174.062-.323.186-.446a.614.614 0 01.448-.184c.169 0 .315.06.44.182.124.122.186.27.186.448a.6.6 0 01-.189.446.607.607 0 01-.437.184zM2 14a1 1 0 01-.878-1.479l6-11a1 1 0 011.756 0l6 11A1 1 0 0114 14H2zm0-1h12L8 2 2 13z"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <span
-            class="euiToastHeader__title"
-          >
-            Error loading report details.
-          </span>
-        </div>
-        <button
-          aria-label="Dismiss toast"
-          class="euiToast__closeButton"
-          data-test-subj="toastCloseButton"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
+    />
   </main>
 </div>
 `;
@@ -532,7 +510,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             >
               <h2
                 class="euiTitle euiTitle--medium"
-              />
+              >
+                test create report definition trigger
+              </h2>
             </div>
           </div>
         </div>
@@ -564,7 +544,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              test create report definition trigger
+            </dd>
           </dl>
         </div>
         <div
@@ -580,7 +562,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -596,7 +580,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -612,7 +598,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
       </div>
@@ -638,11 +626,11 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             >
               <a
                 class="euiLink euiLink--primary"
-                href=""
+                href="http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))"
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                
+                Dashboard
               </a>
             </dd>
           </dl>
@@ -660,7 +648,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              Invalid Date -&gt; 10/23/2020, 1:53:35 PM
+            </dd>
           </dl>
         </div>
         <div
@@ -732,7 +722,11 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
         <div
@@ -748,7 +742,11 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
         <div
@@ -784,70 +782,22 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
         class="euiSpacer euiSpacer--l"
       />
       <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexItem"
       >
-        <div
-          class="euiFlexItem"
+        <dl
+          class="euiDescriptionList euiDescriptionList--row"
         >
-          <dl
-            class="euiDescriptionList euiDescriptionList--row"
+          <dt
+            class="euiDescriptionList__title"
           >
-            <dt
-              class="euiDescriptionList__title"
-            >
-              Report trigger
-            </dt>
-            <dd
-              class="euiDescriptionList__description"
-            />
-          </dl>
-        </div>
-        <div
-          class="euiFlexItem"
-        >
-          <dl
-            class="euiDescriptionList euiDescriptionList--row"
+            Report trigger
+          </dt>
+          <dd
+            class="euiDescriptionList__description"
           >
-            <dt
-              class="euiDescriptionList__title"
-            >
-              Schedule type
-            </dt>
-            <dd
-              class="euiDescriptionList__description"
-            />
-          </dl>
-        </div>
-        <div
-          class="euiFlexItem"
-        >
-          <dl
-            class="euiDescriptionList euiDescriptionList--row"
-          >
-            <dt
-              class="euiDescriptionList__title"
-            >
-              Schedule details
-            </dt>
-            <dd
-              class="euiDescriptionList__description"
-            />
-          </dl>
-        </div>
-        <div
-          class="euiFlexItem"
-        >
-          <dl
-            class="euiDescriptionList euiDescriptionList--row"
-          >
-            <dt
-              class="euiDescriptionList__title"
-            />
-            <dd
-              class="euiDescriptionList__description"
-            />
-          </dl>
-        </div>
+            On demand
+          </dd>
+        </dl>
       </div>
       <div
         class="euiSpacer euiSpacer--l"
@@ -876,7 +826,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -892,7 +844,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -908,7 +862,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -924,7 +880,11 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
       </div>
@@ -933,56 +893,7 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
       aria-live="polite"
       class="euiGlobalToastList euiGlobalToastList--right"
       role="region"
-    >
-      <div
-        class="euiToast euiToast--danger euiGlobalToastListItem"
-        id="reportDetailsErrorToast"
-      >
-        <p
-          class="euiScreenReaderOnly"
-        >
-          A new notification appears
-        </p>
-        <div
-          aria-label="Notification"
-          class="euiToastHeader"
-          data-test-subj="euiToastHeader"
-        >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiToastHeader__icon"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-          <span
-            class="euiToastHeader__title"
-          >
-            Error loading report details.
-          </span>
-        </div>
-        <button
-          aria-label="Dismiss toast"
-          class="euiToast__closeButton"
-          data-test-subj="toastCloseButton"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium euiIcon-isLoading"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </button>
-      </div>
-    </div>
+    />
   </main>
 </div>
 `;

--- a/dashboards-reports/public/components/main/report_details/__tests__/report_details.test.tsx
+++ b/dashboards-reports/public/components/main/report_details/__tests__/report_details.test.tsx
@@ -59,8 +59,10 @@ describe('<ReportDetails /> panel', () => {
         },
       },
       delivery: {
-        delivery_type: '',
-        delivery_params: {},
+        configIds: [],
+        title: '',
+        textDescription: '',
+        htmlDescription: ''
       },
       trigger: {
         trigger_type: 'On demand',
@@ -70,6 +72,7 @@ describe('<ReportDetails /> panel', () => {
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
       query_url: `http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))`,
+      config_list: []
     });
 
     const { container } = render(
@@ -100,8 +103,10 @@ describe('<ReportDetails /> panel', () => {
         },
       },
       delivery: {
-        delivery_type: '',
-        delivery_params: {},
+        configIds: [],
+        title: '',
+        textDescription: '',
+        htmlDescription: ''
       },
       trigger: {
         trigger_type: 'Schedule',
@@ -123,6 +128,7 @@ describe('<ReportDetails /> panel', () => {
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
       query_url: `http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))`,
+      config_list: []
     });
 
     const { container } = render(

--- a/dashboards-reports/public/components/main/report_details/report_details.tsx
+++ b/dashboards-reports/public/components/main/report_details/report_details.tsx
@@ -323,35 +323,6 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
         handleErrorToast();
       });
     })
-    // httpClient
-    //   .get('../api/reporting/reports/' + reportId)
-    //   .then((response: ReportSchemaType) => {
-    //     handleReportDetails(getReportDetailsData(response));
-    //     props.setBreadcrumbs([
-    //       {
-    //         text: i18n.translate(
-    //           'opensearch.reports.details.breadcrumb.reporting',
-    //           { defaultMessage: 'Reporting' }
-    //         ),
-    //         href: '#',
-    //       },
-    //       {
-    //         text: i18n.translate(
-    //           'opensearch.reports.details.breadcrumb.reportDetails',
-    //           {
-    //             defaultMessage: 'Report details: {name}',
-    //             values: {
-    //               name: response.report_definition.report_params.report_name,
-    //             },
-    //           }
-    //         ),
-    //       },
-    //     ]);
-    //   })
-    //   .catch((error: any) => {
-    //     console.log('Error when fetching report details: ', error);
-    //     handleErrorToast();
-    //   });
   }, []);
 
   const downloadIconDownload = async () => {

--- a/dashboards-reports/public/components/main/report_details/report_details.tsx
+++ b/dashboards-reports/public/components/main/report_details/report_details.tsx
@@ -44,7 +44,7 @@ import {
   EuiIcon,
   EuiGlobalToastList,
 } from '@elastic/eui';
-import { displayDeliveryChannels, fileFormatsUpper, generateReportById } from '../main_utils';
+import { displayDeliveryChannels, fileFormatsUpper, generateReportById, getAvailableNotificationsChannels } from '../main_utils';
 import { GenerateReportLoadingModal } from '../loading_modal';
 import { ReportSchemaType } from '../../../../server/model';
 import { converter } from '../../report_definitions/utils';
@@ -55,6 +55,7 @@ import {
   timeRangeMatcher,
 } from '../../utils/utils';
 import { TRIGGER_TYPE } from '../../../../server/routes/utils/constants';
+import { getChannelsQueryObject } from '../../report_definitions/delivery/delivery_constants';
 
 interface ReportDetails {
   reportName: string;
@@ -227,7 +228,7 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
     );
   };
 
-  const getReportDetailsData = (report: ReportSchemaType) : ReportDetails => {
+  const getReportDetailsData = (report: ReportSchemaType, availableChannels) : ReportDetails => {
     const {
       report_definition: reportDefinition,
       last_updated: lastUpdated,
@@ -272,7 +273,7 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
       triggerType: triggerType,
       scheduleType: triggerParams ? triggerParams.schedule_type : `\u2014`,
       scheduleDetails: `\u2014`,
-      configIds: (configIds.length > 0) ? displayDeliveryChannels(configIds) : `\u2014`,
+      configIds: (configIds.length > 0) ? displayDeliveryChannels(configIds, availableChannels) : `\u2014`,
       title: (title !== '') ? title : `\u2014`,
       textDescription: (textDescription !== '') ? textDescription : `\u2014`,
       htmlDescription: (htmlDescription !== '') ? htmlDescription : `\u2014`,
@@ -284,9 +285,18 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
   useEffect(() => {
     const { httpClient } = props;
     httpClient
+    .get('../api/notifications/get_configs', {
+      query: getChannelsQueryObject
+    })
+    .then(async (response: any) => {
+      let availableChannels = getAvailableNotificationsChannels(response.config_list);
+      return availableChannels;
+    })
+    .then((availableChannels: any) => {
+      httpClient
       .get('../api/reporting/reports/' + reportId)
       .then((response: ReportSchemaType) => {
-        handleReportDetails(getReportDetailsData(response));
+        handleReportDetails(getReportDetailsData(response, availableChannels));
         props.setBreadcrumbs([
           {
             text: i18n.translate(
@@ -312,6 +322,36 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
         console.log('Error when fetching report details: ', error);
         handleErrorToast();
       });
+    })
+    // httpClient
+    //   .get('../api/reporting/reports/' + reportId)
+    //   .then((response: ReportSchemaType) => {
+    //     handleReportDetails(getReportDetailsData(response));
+    //     props.setBreadcrumbs([
+    //       {
+    //         text: i18n.translate(
+    //           'opensearch.reports.details.breadcrumb.reporting',
+    //           { defaultMessage: 'Reporting' }
+    //         ),
+    //         href: '#',
+    //       },
+    //       {
+    //         text: i18n.translate(
+    //           'opensearch.reports.details.breadcrumb.reportDetails',
+    //           {
+    //             defaultMessage: 'Report details: {name}',
+    //             values: {
+    //               name: response.report_definition.report_params.report_name,
+    //             },
+    //           }
+    //         ),
+    //       },
+    //     ]);
+    //   })
+    //   .catch((error: any) => {
+    //     console.log('Error when fetching report details: ', error);
+    //     handleErrorToast();
+    //   });
   }, []);
 
   const downloadIconDownload = async () => {

--- a/dashboards-reports/public/components/main/report_details/report_details.tsx
+++ b/dashboards-reports/public/components/main/report_details/report_details.tsx
@@ -228,7 +228,10 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
     );
   };
 
-  const getReportDetailsData = (report: ReportSchemaType, availableChannels) : ReportDetails => {
+  const getReportDetailsData = (
+    report: ReportSchemaType, 
+    availableChannels: Array<{ label: string; id: string; }>
+    ) : ReportDetails => {
     const {
       report_definition: reportDefinition,
       last_updated: lastUpdated,
@@ -285,7 +288,7 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
   useEffect(() => {
     const { httpClient } = props;
     httpClient
-    .get('../api/notifications/get_configs', {
+    .get('../api/reporting_notifications/get_configs', {
       query: getChannelsQueryObject
     })
     .then(async (response: any) => {

--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -166,6 +166,22 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
     deliveryChannelError,
     setDeliveryChannelError,
   ] = useState('');
+  const [
+    showDeliverySubjectError, 
+    setShowDeliverySubjectError
+  ] = useState(false);
+  const [
+    deliverySubjectError, 
+    setDeliverySubjectError
+  ] = useState('');
+  const [
+    showDeliveryTextError,
+    setShowDeliveryTextError
+  ] = useState(false);
+  const [
+    deliveryTextError,
+    setDeliveryTextError
+  ] = useState('');
   const [showTimeRangeError, setShowTimeRangeError] = useState(false);
 
   // preserve the state of the request after an invalid create report definition request
@@ -273,6 +289,10 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
       setShowCronError,
       setShowDeliveryChannelError,
       setDeliveryChannelError,
+      setShowDeliverySubjectError,
+      setDeliverySubjectError,
+      setShowDeliveryTextError,
+      setDeliveryTextError
     ).then((response) => {
       error = response;
     });
@@ -372,6 +392,10 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
           reportDefinitionRequest={createReportDefinitionRequest}
           showDeliveryChannelError={showDeliveryChannelError}
           deliveryChannelError={deliveryChannelError}
+          showDeliverySubjectError={showDeliverySubjectError}
+          deliverySubjectError={deliverySubjectError}
+          showDeliveryTextError={showDeliveryTextError}
+          deliveryTextError={deliveryTextError}
         />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">

--- a/dashboards-reports/public/components/report_definitions/delivery/__tests__/delivery.test.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/__tests__/delivery.test.tsx
@@ -61,6 +61,12 @@ const timeRange = {
   timeTo: new Date(1234567890),
 };
 
+global.fetch = jest.fn(() => ({
+  then: jest.fn(() => ({
+    then: jest.fn()
+  }))
+}));
+
 describe('<ReportDelivery /> panel', () => {
   test('render create component', () => {
     const { container } = render(

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -44,6 +44,7 @@ import 'react-mde/lib/styles/css/react-mde-all.css';
 import { reportDefinitionParams } from '../create/create_report_definition';
 import ReactMDE from 'react-mde';
 import { converter } from '../utils';
+import { getAvailableNotificationsChannels } from '../../main/main_utils';
 
 const styles: CSS.Properties = {
   maxWidth: '800px',
@@ -118,6 +119,7 @@ export function ReportDelivery(props: ReportDeliveryProps) {
   }
 
   const defaultCreateDeliveryParams = () => {
+    includeDelivery = false;
     reportDefinitionRequest.delivery = {
       configIds: [],
       title: `\u2014`, // default values before any Notifications settings are configured
@@ -128,7 +130,6 @@ export function ReportDelivery(props: ReportDeliveryProps) {
 
   const sendTestNotificationsMessage = () => {
     // on success, set test message confirmation message
-    console.log('selectedChannels is', selectedChannels);
     // for each config ID in the current channels list
 
     for (let i = 0; i < selectedChannels.length; ++i) {
@@ -139,28 +140,13 @@ export function ReportDelivery(props: ReportDeliveryProps) {
             feature: 'reports'
           }
         })
-        .then(() => {})
+        .then(() => {
+          handleTestMessageConfirmation(testMessageConfirmationMessage);
+        })
         .catch((error: string) => {
           console.log('error sending test message:', error);
         })
     }
-    handleTestMessageConfirmation(testMessageConfirmationMessage)
-  }
-
-  // placeholder type any
-  const getAvailableNotificationsChannels = (configList: any) => {
-    let availableChannels = [];
-    for (let i = 0; i < configList.length; ++i) {
-      let channelEntry = {};
-      if (configList[i].config.feature_list.includes('reports')) {
-        channelEntry = {
-          label: configList[i].config.name,
-          id: configList[i].config_id
-        }
-        availableChannels.push(channelEntry);
-      }
-    }
-    return availableChannels;
   }
 
   useEffect(() => {

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -39,7 +39,7 @@ import {
   EuiButton,
 } from '@elastic/eui';
 import CSS from 'csstype';
-import { getChannelsQueryObject, placeholderChannels, testMessageConfirmationMessage } from './delivery_constants';
+import { getChannelsQueryObject, testMessageConfirmationMessage } from './delivery_constants';
 import 'react-mde/lib/styles/css/react-mde-all.css';
 import { reportDefinitionParams } from '../create/create_report_definition';
 import ReactMDE from 'react-mde';
@@ -131,10 +131,9 @@ export function ReportDelivery(props: ReportDeliveryProps) {
   const sendTestNotificationsMessage = () => {
     // on success, set test message confirmation message
     // for each config ID in the current channels list
-
     for (let i = 0; i < selectedChannels.length; ++i) {
       httpClientProps
-        .get(`../api/notifications/test_message/${selectedChannels[i].id}`, 
+        .get(`../api/reporting_notifications/test_message/${selectedChannels[i].id}`, 
         {
           query: {
             feature: 'reports'
@@ -151,7 +150,7 @@ export function ReportDelivery(props: ReportDeliveryProps) {
 
   useEffect(() => {
     httpClientProps
-      .get('../api/notifications/get_configs', {
+      .get('../api/reporting_notifications/get_configs', {
         query: getChannelsQueryObject
       })
       .then(async (response: any) => {  
@@ -176,7 +175,8 @@ export function ReportDelivery(props: ReportDeliveryProps) {
                         label: availableChannels[j].label,
                         id: availableChannels[j].id
                       };
-                      editChannelOptions.push(editChannelOption);                  
+                      editChannelOptions.push(editChannelOption);
+                      break;                  
                     }
                   }
                 }

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -173,6 +173,8 @@ export function ReportDelivery(props: ReportDeliveryProps) {
     if (selectedChannels.length === 0) {
       handleTestMessageConfirmation(noDeliveryChannelsSelectedMessage);
     }
+    let testMessageFailures = false;
+    let failedChannels: string[] = [];
     // for each config ID in the current channels list
     for (let i = 0; i < selectedChannels.length; ++i) {
       try {
@@ -189,16 +191,19 @@ export function ReportDelivery(props: ReportDeliveryProps) {
           .then((response) => {
             if (!response.success) {
               const error = new Error('Failed to send the test message.');
+              failedChannels.push(response.status_list[0].config_name);
+              error.stack = JSON.stringify(response.status_list, null, 2);
               throw error;
-            }
-            else {
-              handleTestMessageConfirmation(testMessageConfirmationMessage);
             }
           });
       } catch (error) {
-        // error message
-        handleTestMessageConfirmation(testMessageFailureMessage);
+        testMessageFailures = true;
       }
+    }
+    if (testMessageFailures) {
+      handleTestMessageConfirmation(testMessageFailureMessage(failedChannels));
+    } else {
+      handleTestMessageConfirmation(testMessageConfirmationMessage);
     }
   }
 

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -50,7 +50,7 @@ import { reportDefinitionParams } from '../create/create_report_definition';
 import ReactMDE from 'react-mde';
 import { converter } from '../utils';
 import { getAvailableNotificationsChannels } from '../../main/main_utils';
-import { NOTIFICATIONS_DASHBOARDS_API } from '../../../../common';
+import { REPORTING_NOTIFICATIONS_DASHBOARDS_API } from '../../../../common';
 
 const styles: CSS.Properties = {
   maxWidth: '800px',
@@ -164,7 +164,7 @@ export function ReportDelivery(props: ReportDeliveryProps) {
 
   const getNotification = async (id: string) => {
     const response = await httpClientProps.get(
-      `${NOTIFICATIONS_DASHBOARDS_API.GET_EVENT}/${id}`
+      `${REPORTING_NOTIFICATIONS_DASHBOARDS_API.GET_EVENT}/${id}`
     );
     return eventToNotification(response.event_list[0]);
   };
@@ -177,7 +177,7 @@ export function ReportDelivery(props: ReportDeliveryProps) {
     for (let i = 0; i < selectedChannels.length; ++i) {
       try {
         const eventId = await httpClientProps
-          .get(`${NOTIFICATIONS_DASHBOARDS_API.SEND_TEST_MESSAGE}/${selectedChannels[i].id}`, 
+          .get(`${REPORTING_NOTIFICATIONS_DASHBOARDS_API.SEND_TEST_MESSAGE}/${selectedChannels[i].id}`, 
           {
             query: {
               feature: 'reports'
@@ -229,7 +229,7 @@ export function ReportDelivery(props: ReportDeliveryProps) {
   useEffect(() => {
     checkIfNotificationsPluginIsInstalled();
     httpClientProps
-      .get(`${NOTIFICATIONS_DASHBOARDS_API.GET_CONFIGS}`, {
+      .get(`${REPORTING_NOTIFICATIONS_DASHBOARDS_API.GET_CONFIGS}`, {
         query: getChannelsQueryObject
       })
       .then(async (response: any) => {  

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -176,7 +176,6 @@ export function ReportDelivery(props: ReportDeliveryProps) {
                         label: availableChannels[j].label,
                         id: availableChannels[j].id
                       };
-                      console.log('edit channel option is', editChannelOption);
                       editChannelOptions.push(editChannelOption);                  
                     }
                   }

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
@@ -33,6 +33,14 @@ export const testMessageConfirmationMessage = (
   </EuiText>
 );
 
+export const getChannelsQueryObject = {
+  config_type: ['slack', 'email', 'chime', 'webhook', 'sns', 'ses'],
+  from_index: 0,
+  max_items: 10,
+  sort_field: 'name',
+  sort_order: 'asc'
+}
+
 // TODO: Remove and replace references after connecting to backend
 export const placeholderChannels = [
   {

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
@@ -39,9 +39,9 @@ export const testMessageConfirmationMessage = (
   </EuiText>
 );
 
-export const testMessageFailureMessage = (
+export const testMessageFailureMessage = (failedChannels: Array<string>) => (
   <EuiText size='s'>
-    <EuiIcon type='alert'/> Failed to send test message. Please adjust channel settings.
+    <EuiIcon type='alert'/> Failed to send test message for some channels. Please adjust channel settings for {failedChannels.toString()}
   </EuiText>
 )
 

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
@@ -33,6 +33,12 @@ export const testMessageConfirmationMessage = (
   </EuiText>
 );
 
+export const testMessageFailureMessage = (
+  <EuiText size='s'>
+    <EuiIcon type='alert'/> Failed to send test message. Please adjust channel settings.
+  </EuiText>
+)
+
 export const getChannelsQueryObject = {
   config_type: ['slack', 'email', 'chime', 'webhook', 'sns', 'ses'],
   from_index: 0,

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
@@ -27,6 +27,12 @@ import { EuiIcon, EuiText } from '@elastic/eui'
  * permissions and limitations under the License.
  */
 
+export const noDeliveryChannelsSelectedMessage = (
+  <EuiText size='s'>
+    <EuiIcon type='alert'/> Please select a channel. 
+  </EuiText>
+)
+
 export const testMessageConfirmationMessage = (
   <EuiText size='s'>
     <EuiIcon type='check'/> Test message sent to selected channels. If no test message is received, try again or check your channel settings in Notifications.

--- a/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery_constants.tsx
@@ -36,19 +36,8 @@ export const testMessageConfirmationMessage = (
 export const getChannelsQueryObject = {
   config_type: ['slack', 'email', 'chime', 'webhook', 'sns', 'ses'],
   from_index: 0,
-  max_items: 10,
+  max_items: 1000,
   sort_field: 'name',
-  sort_order: 'asc'
+  sort_order: 'asc',
+  feature_list: ['reports']
 }
-
-// TODO: Remove and replace references after connecting to backend
-export const placeholderChannels = [
-  {
-    label: 'Chime',
-    id: 'abcdefghijk'
-  },
-  {
-    label: 'Slack',
-    id: 'zyxwvutsrq'
-  }
-]

--- a/dashboards-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
+++ b/dashboards-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<ReportSettings /> panel dashboard create from in-context 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -1193,7 +1193,7 @@ exports[`<ReportSettings /> panel display errors on create 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -2383,7 +2383,7 @@ exports[`<ReportSettings /> panel render component 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -2989,7 +2989,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -3614,7 +3614,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 2`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -4239,7 +4239,7 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -4864,7 +4864,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -5489,7 +5489,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 2`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -6114,7 +6114,7 @@ exports[`<ReportSettings /> panel saved search create from in-context 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr
@@ -7297,7 +7297,7 @@ exports[`<ReportSettings /> panel visualization create from in-context 1`] = `
     <h2
       class="euiTitle euiTitle--medium"
     >
-      Report Settings
+      Report settings
     </h2>
   </div>
   <hr

--- a/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/dashboards-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -835,7 +835,7 @@ export function ReportSettings(props: ReportSettingProps) {
           <h2>
             {i18n.translate(
               'opensearch.reports.reportSettingProps.form.reportSettings',
-              { defaultMessage: 'Report Settings' }
+              { defaultMessage: 'Report settings' }
             )}
           </h2>
         </EuiTitle>

--- a/dashboards-reports/public/components/report_definitions/utils/utils.tsx
+++ b/dashboards-reports/public/components/report_definitions/utils/utils.tsx
@@ -42,6 +42,10 @@ export const definitionInputValidation = async (
   setShowCronError,
   setShowDeliveryChannelError,
   setDeliveryChannelsErrorMessage, 
+  setShowDeliverySubjectError,
+  setDeliverySubjectError,
+  setShowDeliveryTextError,
+  setDeliveryTextError
 ) => {
   // check report name
   // allow a-z, A-Z, 0-9, (), [], ',' - and _ and spaces
@@ -101,16 +105,40 @@ export const definitionInputValidation = async (
     }
   }
   // delivery
-  if (metadata.delivery.configIds.length === 0 && includeDelivery) {
-    // no channels are listed
-    setShowDeliveryChannelError(true);
-    setDeliveryChannelsErrorMessage(
-      i18n.translate(
-        'opensearch.reports.error.channelListCannotBeEmpty',
-        { defaultMessage: 'Channels list cannot be empty.' }
-      )
-    );
-    error = true;
+  if (includeDelivery) {
+    if (metadata.delivery.configIds.length === 0) {
+      // no channels are listed
+      setShowDeliveryChannelError(true);
+      setDeliveryChannelsErrorMessage(
+        i18n.translate(
+          'opensearch.reports.error.channelListCannotBeEmpty',
+          { defaultMessage: 'Channels list cannot be empty.' }
+        )
+      );
+      error = true;
+    }
+    // subject is empty
+    if (metadata.delivery.title === '') {
+      setShowDeliverySubjectError(true);
+      setDeliverySubjectError(
+        i18n.translate(
+          'opensearch.reports.error.deliverySubjectCannotBeEmpty',
+          { defaultMessage: 'Subject cannot be empty.' }
+        )
+      );
+      error = true;
+    }
+    // message is empty
+    if (metadata.delivery.textDescription === '') {
+      setShowDeliveryTextError(true);
+      setDeliveryTextError(
+        i18n.translate(
+          'opensearch.reports.error.deliverySubjectCannotBeEmpty',
+          { defaultMessage: 'Subject cannot be empty.' }
+        )
+      );
+      error = true;
+    }    
   }
   return error;
 };

--- a/dashboards-reports/server/clusters/notificationsPlugin.ts
+++ b/dashboards-reports/server/clusters/notificationsPlugin.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { NOTIFICATIONS_API } from '../../common';
+
+export function NotificationsPlugin(Client: any, config: any, components: any) {
+  const clientAction = components.clientAction.factory;
+
+  Client.prototype.notifications = components.clientAction.namespaceFactory();
+  const notifications = Client.prototype.notifications.prototype;
+
+  notifications.getConfigs = clientAction({
+    url: {
+      fmt: NOTIFICATIONS_API.CONFIGS,
+    },
+    method: 'GET',
+  });
+
+  notifications.sendTestMessage = clientAction({
+    url: {
+      fmt: `${NOTIFICATIONS_API.TEST_MESSAGE}/<%=configId%>`,
+      req: {
+        configId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'GET',
+  });
+}

--- a/dashboards-reports/server/clusters/notificationsPlugin.ts
+++ b/dashboards-reports/server/clusters/notificationsPlugin.ts
@@ -24,6 +24,19 @@ export function NotificationsPlugin(Client: any, config: any, components: any) {
     method: 'GET',
   });
 
+  notifications.getEventById = clientAction({
+    url: {
+      fmt: `${NOTIFICATIONS_API.EVENTS}/<%=eventId%>`,
+      req: {
+        eventId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'GET',
+  })
+
   notifications.sendTestMessage = clientAction({
     url: {
       fmt: `${NOTIFICATIONS_API.TEST_MESSAGE}/<%=configId%>`,

--- a/dashboards-reports/server/plugin.ts
+++ b/dashboards-reports/server/plugin.ts
@@ -43,6 +43,7 @@ import registerRoutes from './routes';
 import { pollAndExecuteJob } from './executor/executor';
 import { POLL_INTERVAL } from './utils/constants';
 import { AccessInfoType } from 'server';
+import { NotificationsPlugin } from './clusters/notificationsPlugin';
 
 export interface ReportsPluginRequestContext {
   logger: Logger;
@@ -84,7 +85,14 @@ export class ReportsDashboardsPlugin
     const opensearchReportsClient: ILegacyClusterClient = core.opensearch.legacy.createClient(
       'opensearch_reports',
       {
-        plugins: [opensearchReportsPlugin],
+        plugins: [opensearchReportsPlugin, NotificationsPlugin],
+      }
+    );
+
+    const notificationsClient: ILegacyClusterClient = core.opensearch.legacy.createClient(
+      'opensearch_notifications',
+      {
+        plugins: [NotificationsPlugin],
       }
     );
 
@@ -100,6 +108,7 @@ export class ReportsDashboardsPlugin
           logger: this.logger,
           semaphore: this.semaphore,
           opensearchReportsClient,
+          notificationsClient
         };
       }
     );

--- a/dashboards-reports/server/routes/index.ts
+++ b/dashboards-reports/server/routes/index.ts
@@ -28,6 +28,7 @@ import registerReportRoute from './report';
 import registerReportDefinitionRoute from './reportDefinition';
 import registerReportSourceRoute from './reportSource';
 import registerMetricRoute from './metric';
+import registerNotificationRoute from './notifications';
 import { IRouter } from '../../../../src/core/server';
 import { AccessInfoType } from 'server';
 
@@ -36,4 +37,5 @@ export default function (router: IRouter, accessInfo: AccessInfoType) {
   registerReportDefinitionRoute(router, accessInfo);
   registerReportSourceRoute(router);
   registerMetricRoute(router);
+  registerNotificationRoute(router);
 }

--- a/dashboards-reports/server/routes/notifications.ts
+++ b/dashboards-reports/server/routes/notifications.ts
@@ -10,7 +10,7 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { NOTIFICATIONS_DASHBOARDS_API } from '../../common';
+import { REPORTING_NOTIFICATIONS_DASHBOARDS_API } from '../../common';
 import {
   IRouter,
   IOpenSearchDashboardsResponse,
@@ -24,7 +24,7 @@ export default function(router: IRouter) {
   // Get all configs from Notifications
   router.get(
     {
-      path: NOTIFICATIONS_DASHBOARDS_API.GET_CONFIGS,
+      path: REPORTING_NOTIFICATIONS_DASHBOARDS_API.GET_CONFIGS,
       validate: {
         query: schema.object({
           from_index: schema.number(),
@@ -83,7 +83,7 @@ export default function(router: IRouter) {
   // get event by id
   router.get(
     {
-      path: `${NOTIFICATIONS_DASHBOARDS_API.GET_EVENT}/{eventId}`,
+      path: `${REPORTING_NOTIFICATIONS_DASHBOARDS_API.GET_EVENT}/{eventId}`,
       validate: {
         params: schema.object({
           eventId: schema.string(),
@@ -113,7 +113,7 @@ export default function(router: IRouter) {
   // Send test message
   router.get(
     {
-      path: `${NOTIFICATIONS_DASHBOARDS_API.SEND_TEST_MESSAGE}/{configId}`,
+      path: `${REPORTING_NOTIFICATIONS_DASHBOARDS_API.SEND_TEST_MESSAGE}/{configId}`,
       validate: {
         params: schema.object({
           configId: schema.string(),

--- a/dashboards-reports/server/routes/notifications.ts
+++ b/dashboards-reports/server/routes/notifications.ts
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { schema } from '@osd/config-schema';
+import { NOTIFICATIONS_DASHBOARDS_API } from '../../common';
+import {
+  IRouter,
+  IOpenSearchDashboardsResponse,
+  ResponseError,
+  Logger,
+  ILegacyScopedClusterClient,
+} from '../../../../src/core/server';
+import { joinRequestParams } from './utils/helpers';
+
+export default function(router: IRouter) {
+  // Get all configs from Notifications
+  router.get(
+    {
+      path: NOTIFICATIONS_DASHBOARDS_API.GET_CONFIGS,
+      validate: {
+        query: schema.object({
+          from_index: schema.number(),
+          max_items: schema.number(),
+          query: schema.maybe(schema.string()),
+          config_type: schema.oneOf([
+            schema.arrayOf(schema.string()),
+            schema.string()
+          ]),
+          feature_list: schema.maybe(
+            schema.oneOf([schema.arrayOf(schema.string()), schema.string()])
+          ),
+          is_enabled: schema.maybe(schema.boolean()),
+          sort_field: schema.string(),
+          sort_order: schema.string(),
+          config_id_list: schema.maybe(
+            schema.oneOf([schema.arrayOf(schema.string()), schema.string()])
+          ),
+        })
+      }
+    },
+    async (context, request, response) => {
+      const config_type = joinRequestParams(request.query.config_type);
+      const feature_list = joinRequestParams(request.query.feature_list);
+      const config_id_list = joinRequestParams(request.query.config_id_list);
+      const query = request.query.query;
+      // @ts-ignore
+      const client: ILegacyScopedClusterClient = context.reporting_plugin.notificationsClient.asScoped(
+        request
+      );
+      try {
+        const resp = await client.callAsCurrentUser(
+          'notifications.getConfigs',
+          {
+            from_index: request.query.from_index,
+            max_items: request.query.max_items,
+            is_enabled: request.query.is_enabled,
+            sort_field: request.query.sort_field,
+            sort_order: request.query.sort_order,
+            config_type,
+            ...(feature_list && { feature_list }),
+            ...(query && { query }),
+            ...(config_id_list && { config_id_list }),
+          }
+        );
+        return response.ok({ body: resp });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+
+  // Send test message
+  router.get(
+    {
+      path: `${NOTIFICATIONS_DASHBOARDS_API.SEND_TEST_MESSAGE}/{configId}`,
+      validate: {
+        params: schema.object({
+          configId: schema.string(),
+        }),
+        query: schema.object({
+          feature: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      // @ts-ignore
+      const client: ILegacyScopedClusterClient = context.reporting_plugin.notificationsClient.asScoped(
+        request
+      );
+      try {
+        const resp = await client.callAsCurrentUser(
+          'notifications.sendTestMessage',
+          {
+            configId: request.params.configId,
+            feature: request.query.feature,
+          }
+        );
+        return response.ok({ body: resp });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+}

--- a/dashboards-reports/server/routes/notifications.ts
+++ b/dashboards-reports/server/routes/notifications.ts
@@ -80,6 +80,36 @@ export default function(router: IRouter) {
     }
   );
 
+  // get event by id
+  router.get(
+    {
+      path: `${NOTIFICATIONS_DASHBOARDS_API.GET_EVENT}/{eventId}`,
+      validate: {
+        params: schema.object({
+          eventId: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      // @ts-ignore
+      const client: ILegacyScopedClusterClient = context.reporting_plugin.notificationsClient.asScoped(
+        request
+      );
+      try {
+        const resp = await client.callAsCurrentUser(
+          'notifications.getEventById',
+          { eventId: request.params.eventId }
+        );
+        return response.ok({ body: resp });
+      } catch (error) {
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  )
+
   // Send test message
   router.get(
     {

--- a/dashboards-reports/server/routes/utils/helpers.ts
+++ b/dashboards-reports/server/routes/utils/helpers.ts
@@ -105,3 +105,11 @@ export const checkErrorType = (error: any) => {
     return 'system_error';
   }
 };
+
+export const joinRequestParams = (
+  queryParams: string | string[] | undefined
+) => {
+  if (Array.isArray(queryParams)) return queryParams.join(',');
+  if (typeof queryParams === 'string') return queryParams;
+  return '';
+};

--- a/dashboards-reports/test/httpMockClient.js
+++ b/dashboards-reports/test/httpMockClient.js
@@ -33,6 +33,9 @@ httpClientMock.delete = jest.fn(() => ({
 }));
 httpClientMock.get = jest.fn(() => ({
   then: jest.fn(() => ({
+    then: jest.fn(() => ({
+      catch: jest.fn()
+    })),
     catch: jest.fn(),
   })),
 }));

--- a/dashboards-reports/translations/pl.json
+++ b/dashboards-reports/translations/pl.json
@@ -118,6 +118,8 @@
     "opensearch.reports.editReportDefinition.save": "Zapisz zmiany",
     "opensearch.reports.editReportDefinition.title": "Edytuj definicję raportu.",
     "opensearch.reports.error.channelListCannotBeEmpty": "Lista kanałów nie może być pusta.",
+    "opensearch.reports.error.deliverySubjectCannotBeEmpty": "Temat nie może być pusty.",
+    "opensearch.reports.error.deliveryTextCannotBeEmpty": "Tekst dostawy nie może być pusty",
     "opensearch.reports.error.reportSourceMustNotBeEmpty": "Źródło raportu nie może być puste.",
     "opensearch.reports.loading.close": "Zamknij",
     "opensearch.reports.loading.generatingReport": "Generowanie raportu.",


### PR DESCRIPTION
### Description
Connect Notifications APIs to Reporting
* Channel display in `Notification Settings` will display available channels with reporting listed
* `Send test message` connects to send a test message to the channels listed
* Details pages updated to display correct channels after getting list of available channels
* Add needed Notifications APIs implemented in `dashboards-reports` server to eliminate dependency on `dashboards-notifications` and only have dependency on `opensearch-notifications`
* Check `_cat/plugins` to see if `opensearch-notifications` is installed to toggle whether the `Notification settings` section is displayed
* Jest tests updated 
* Changed `Report Settings` to `Report settings`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
