### PR TITLE
Bump opensearch ref to 1.1 in CI

### DIFF
--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
-  OPENSEARCH_BRANCH: '1.x'
+  OPENSEARCH_BRANCH: '1.1'
   COMMON_UTILS_BRANCH: 'main'
   JOB_SCHEDULER_BRANCH: 'main'
 
@@ -77,4 +77,4 @@ jobs:
         with:
           name: reports-scheduler
           path: reports-scheduler-builds
-          
+

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ We welcome you to get involved in development, documentation, testing the OpenSe
 
 ## Setup & Build
 
-Complete OpenSearch Dashboards Report feature is composed of 2 plugins. Refer to README in each plugin folder for more details.
+Complete OpenSearch Dashboards Report feature is composed of 2 plugins.
 
 - [OpenSearch Dashboards reports plugin](./dashboards-reports/README.md)
-- [OpenSearch Reports scheduler plugin](./reports-scheduler/README.md)（TODO）
+- OpenSearch Reports scheduler plugin
 
 ## Notifications Integration
 
@@ -54,7 +54,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## License
 
-See the [LICENSE](./LICENSE.txt) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](./LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 ## Copyright
 

--- a/release-notes/opensearch-dashboards-reports.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-dashboards-reports.release-notes-1.1.0.0.md
@@ -1,0 +1,14 @@
+## Version 1.1.0.0 Release Notes
+
+Compatible with OpenSearch 1.1.0
+
+### Bug Fixes
+* Fix url validation ([#132](https://github.com/opensearch-project/dashboards-reports/pull/132))
+* Fix url validation for context menu ([#134](https://github.com/opensearch-project/dashboards-reports/pull/134))
+
+### Infrastructure
+* Bump opensearch ref to 1.1 in CI ([#155](https://github.com/opensearch-project/dashboards-reports/pull/155))
+
+### Infrastructure
+* Fix snapshot build and upgrade to OpenSearch 1.1 ([#140](https://github.com/opensearch-project/dashboards-reports/pull/140))
+* Bump version for Opensearch 1.1.0 release ([#149](https://github.com/opensearch-project/dashboards-reports/pull/149))


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Core has `1.1` branch cut and bumped `1.x` minor version to `1.2`, use opensearch ref to 1.1 in CI

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
