### PR TITLE
Remove hard coded localhost when calling API

### DIFF
--- a/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/dashboards-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -215,7 +215,6 @@ export function ReportDelivery(props: ReportDeliveryProps) {
           "Accept-Language": "en-US,en;q=0.5",
           "osd-xsrf": "true"
       },
-      "referrer": "http://localhost:5601/app/dev_tools",
       "method": "POST",
       "mode": "cors"
     })


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>
### Description
This breaks if user is connecting to a remote endpoint, or if has base path configured. Use relative url instead

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
