### PR TITLE
Catch Notifications Errors on Details Pages

### DIFF
--- a/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -497,6 +497,9 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
       setChannels(availableChannels);
       return availableChannels;
     })
+    .catch((error: any) => {
+      console.log('error when retrieving notification configs:', error);
+    })
     .then((availableChannels: any) => {
       httpClient
       .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)

--- a/dashboards-reports/public/components/main/report_details/report_details.tsx
+++ b/dashboards-reports/public/components/main/report_details/report_details.tsx
@@ -292,8 +292,12 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
       query: getChannelsQueryObject
     })
     .then(async (response: any) => {
+      console.log('notification get configs is', response);
       let availableChannels = getAvailableNotificationsChannels(response.config_list);
       return availableChannels;
+    })
+    .catch((error: any) => {
+      console.log('error when retrieving notification configs:', error);
     })
     .then((availableChannels: any) => {
       httpClient

--- a/dashboards-reports/public/components/main/report_details/report_details.tsx
+++ b/dashboards-reports/public/components/main/report_details/report_details.tsx
@@ -292,7 +292,6 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
       query: getChannelsQueryObject
     })
     .then(async (response: any) => {
-      console.log('notification get configs is', response);
       let availableChannels = getAvailableNotificationsChannels(response.config_list);
       return availableChannels;
     })


### PR DESCRIPTION
Signed-off by: David Cui <davidcui@amazon.com>

### Description
Add catch blocks to Notifications `get_configs` calls in `Report details` and `Report definition details` to prevent errors from crashing the page. 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
