### PR TITLE
Remove Notifications from Create/Edit

### DIFF
--- a/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -37,7 +37,6 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { ReportSettings } from '../report_settings';
-import { ReportDelivery } from '../delivery';
 import { generateReportFromDefinitionId } from '../../main/main_utils';
 import { converter } from '../utils';
 import {
@@ -159,29 +158,6 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
     setShowTriggerIntervalNaNError,
   ] = useState(false);
   const [showCronError, setShowCronError] = useState(false);
-  const [showDeliveryChannelError, setShowDeliveryChannelError] = useState(
-    false
-  );
-  const [
-    deliveryChannelError,
-    setDeliveryChannelError,
-  ] = useState('');
-  const [
-    showDeliverySubjectError, 
-    setShowDeliverySubjectError
-  ] = useState(false);
-  const [
-    deliverySubjectError, 
-    setDeliverySubjectError
-  ] = useState('');
-  const [
-    showDeliveryTextError,
-    setShowDeliveryTextError
-  ] = useState(false);
-  const [
-    deliveryTextError,
-    setDeliveryTextError
-  ] = useState('');
   const [showTimeRangeError, setShowTimeRangeError] = useState(false);
 
   // preserve the state of the request after an invalid create report definition request
@@ -287,12 +263,6 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
       timeRange,
       setShowTimeRangeError,
       setShowCronError,
-      setShowDeliveryChannelError,
-      setDeliveryChannelError,
-      setShowDeliverySubjectError,
-      setDeliverySubjectError,
-      setShowDeliveryTextError,
-      setDeliveryTextError
     ).then((response) => {
       error = response;
     });
@@ -383,19 +353,6 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
           showTimeRangeError={showTimeRangeError}
           showTriggerIntervalNaNError={showTriggerIntervalNaNError}
           showCronError={showCronError}
-        />
-        <EuiSpacer />
-        <ReportDelivery
-          edit={false}
-          editDefinitionId={''}
-          httpClientProps={props['httpClient']}
-          reportDefinitionRequest={createReportDefinitionRequest}
-          showDeliveryChannelError={showDeliveryChannelError}
-          deliveryChannelError={deliveryChannelError}
-          showDeliverySubjectError={showDeliverySubjectError}
-          deliverySubjectError={deliverySubjectError}
-          showDeliveryTextError={showDeliveryTextError}
-          deliveryTextError={deliveryTextError}
         />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">

--- a/dashboards-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/dashboards-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -38,7 +38,6 @@ import {
   EuiGlobalToastList,
 } from '@elastic/eui';
 import { ReportSettings } from '../report_settings';
-import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
 import { ReportDefinitionSchemaType } from 'server/model';
 import { converter } from '../utils';
@@ -74,13 +73,6 @@ export function EditReportDefinition(props: { [x: string]: any; setBreadcrumbs?:
     setShowTriggerIntervalNaNError,
   ] = useState(false);
   const [showCronError, setShowCronError] = useState(false);
-  const [showDeliveryChannelError, setShowDeliveryChannelError] = useState(
-    false
-  );
-  const [
-    deliveryChannelError,
-    setDeliveryChannelError,
-  ] = useState('');
   const [showTimeRangeError, setShowTimeRangeError] = useState(false);
 
   const addPermissionsMissingViewEditPageToastHandler = (errorType: string) => {
@@ -262,8 +254,6 @@ export function EditReportDefinition(props: { [x: string]: any; setBreadcrumbs?:
       timeRange,
       setShowTimeRangeError,
       setShowCronError,
-      setShowDeliveryChannelError,
-      setDeliveryChannelError
     ).then((response) => {
       error = response;
     });
@@ -345,15 +335,6 @@ export function EditReportDefinition(props: { [x: string]: any; setBreadcrumbs?:
           showTimeRangeError={showTimeRangeError}
           showTriggerIntervalNaNError={showTriggerIntervalNaNError}
           showCronError={showCronError}
-        />
-        <EuiSpacer />
-        <ReportDelivery
-          edit={true}
-          editDefinitionId={reportDefinitionId}
-          reportDefinitionRequest={editReportDefinitionRequest}
-          httpClientProps={props['httpClient']}
-          showDeliveryChannelError={showDeliveryChannelError}
-          deliveryChannelError={deliveryChannelError}
         />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">

--- a/dashboards-reports/public/components/report_definitions/utils/utils.tsx
+++ b/dashboards-reports/public/components/report_definitions/utils/utils.tsx
@@ -39,13 +39,7 @@ export const definitionInputValidation = async (
   setShowTriggerIntervalNaNError,
   timeRange,
   setShowTimeRangeError,
-  setShowCronError,
-  setShowDeliveryChannelError,
-  setDeliveryChannelsErrorMessage, 
-  setShowDeliverySubjectError,
-  setDeliverySubjectError,
-  setShowDeliveryTextError,
-  setDeliveryTextError
+  setShowCronError
 ) => {
   // check report name
   // allow a-z, A-Z, 0-9, (), [], ',' - and _ and spaces
@@ -103,42 +97,6 @@ export const definitionInputValidation = async (
       setShowCronError(true);
       error = true;
     }
-  }
-  // delivery
-  if (includeDelivery) {
-    if (metadata.delivery.configIds.length === 0) {
-      // no channels are listed
-      setShowDeliveryChannelError(true);
-      setDeliveryChannelsErrorMessage(
-        i18n.translate(
-          'opensearch.reports.error.channelListCannotBeEmpty',
-          { defaultMessage: 'Channels list cannot be empty.' }
-        )
-      );
-      error = true;
-    }
-    // subject is empty
-    if (metadata.delivery.title === '') {
-      setShowDeliverySubjectError(true);
-      setDeliverySubjectError(
-        i18n.translate(
-          'opensearch.reports.error.deliverySubjectCannotBeEmpty',
-          { defaultMessage: 'Subject cannot be empty.' }
-        )
-      );
-      error = true;
-    }
-    // message is empty
-    if (metadata.delivery.textDescription === '') {
-      setShowDeliveryTextError(true);
-      setDeliveryTextError(
-        i18n.translate(
-          'opensearch.reports.error.deliverySubjectCannotBeEmpty',
-          { defaultMessage: 'Subject cannot be empty.' }
-        )
-      );
-      error = true;
-    }    
   }
   return error;
 };


### PR DESCRIPTION
Signed-off by: David Cui <davidcui@amazon.com>

### Description
Remove references to Notifications/Delivery in `Create report definition` and `Edit report definition`

- Remove delivery from front-end input validation 
- Remove delivery-related hooks
- Delete the `ReportDelivery` component from `Create` and `Edit`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
