### PR TITLE
Change Delete name path to OpenSearch

### DIFF
--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/DeleteReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/DeleteReportDefinitionAction.kt
@@ -51,7 +51,7 @@ internal class DeleteReportDefinitionAction @Inject constructor(
     actionFilters,
     ::DeleteReportDefinitionRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/delete"
+        private const val NAME = "cluster:admin/opensearch/reports/definition/delete"
         internal val ACTION_TYPE = ActionType(NAME, ::DeleteReportDefinitionResponse)
     }
 


### PR DESCRIPTION
Signed-off by: David Cui <davidcui@amazon.com>

### Description
Refactor the name path for DeleteReportDefinitionAction from `opendistro` to `opensearch`. 

### Issues Resolved
#187 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
