### PR TITLE
Revert backend paths to opendistro 

### DIFF
--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/CreateReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/CreateReportDefinitionAction.kt
@@ -51,7 +51,7 @@ internal class CreateReportDefinitionAction @Inject constructor(
     actionFilters,
     ::CreateReportDefinitionRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/definition/create"
+        private const val NAME = "cluster:admin/opendistro/reports/definition/create"
         internal val ACTION_TYPE = ActionType(NAME, ::CreateReportDefinitionResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportDefinitionsAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportDefinitionsAction.kt
@@ -51,7 +51,7 @@ internal class GetAllReportDefinitionsAction @Inject constructor(
     actionFilters,
     ::GetAllReportDefinitionsRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/definition/list"
+        private const val NAME = "cluster:admin/opendistro/reports/definition/list"
         internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportDefinitionsResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportInstancesAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportInstancesAction.kt
@@ -51,7 +51,7 @@ internal class GetAllReportInstancesAction @Inject constructor(
     actionFilters,
     ::GetAllReportInstancesRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/instance/list"
+        private const val NAME = "cluster:admin/opendistro/reports/instance/list"
         internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportInstancesResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportDefinitionAction.kt
@@ -51,7 +51,7 @@ internal class GetReportDefinitionAction @Inject constructor(
     actionFilters,
     ::GetReportDefinitionRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/definition/get"
+        private const val NAME = "cluster:admin/opendistro/reports/definition/get"
         internal val ACTION_TYPE = ActionType(NAME, ::GetReportDefinitionResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportInstanceAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportInstanceAction.kt
@@ -51,7 +51,7 @@ internal class GetReportInstanceAction @Inject constructor(
     actionFilters,
     ::GetReportInstanceRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/instance/get"
+        private const val NAME = "cluster:admin/opendistro/reports/instance/get"
         internal val ACTION_TYPE = ActionType(NAME, ::GetReportInstanceResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/InContextReportCreateAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/InContextReportCreateAction.kt
@@ -51,7 +51,7 @@ internal class InContextReportCreateAction @Inject constructor(
     actionFilters,
     ::InContextReportCreateRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/menu/download"
+        private const val NAME = "cluster:admin/opendistro/reports/menu/download"
         internal val ACTION_TYPE = ActionType(NAME, ::InContextReportCreateResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/OnDemandReportCreateAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/OnDemandReportCreateAction.kt
@@ -51,7 +51,7 @@ internal class OnDemandReportCreateAction @Inject constructor(
     actionFilters,
     ::OnDemandReportCreateRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/definition/on_demand"
+        private const val NAME = "cluster:admin/opendistro/reports/definition/on_demand"
         internal val ACTION_TYPE = ActionType(NAME, ::OnDemandReportCreateResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportDefinitionAction.kt
@@ -51,7 +51,7 @@ internal class UpdateReportDefinitionAction @Inject constructor(
     actionFilters,
     ::UpdateReportDefinitionRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/definition/update"
+        private const val NAME = "cluster:admin/opendistro/reports/definition/update"
         internal val ACTION_TYPE = ActionType(NAME, ::UpdateReportDefinitionResponse)
     }
 

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportInstanceStatusAction.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportInstanceStatusAction.kt
@@ -51,7 +51,7 @@ internal class UpdateReportInstanceStatusAction @Inject constructor(
     actionFilters,
     ::UpdateReportInstanceStatusRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opensearch/reports/instance/update_status"
+        private const val NAME = "cluster:admin/opendistro/reports/instance/update_status"
         internal val ACTION_TYPE = ActionType(NAME, ::UpdateReportInstanceStatusResponse)
     }
 


### PR DESCRIPTION
Signed-off by: David Cui <davidcui@amazon.com>

### Description
Revert backend paths from using `opensearch` to `opendistro` to keep cluster permissions same with ODFE. For example:

`cluster:admin/opensearch/reports/definition/create` vs `cluster:admin/opendistro/reports/definition/create`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
