### PR TITLE
Initialize reporting dashboards-plugin configurations and with reporting server settings

### DIFF
--- a/dashboards-reports/opensearch_dashboards.json
+++ b/dashboards-reports/opensearch_dashboards.json
@@ -5,5 +5,6 @@
   "requiredPlugins": ["navigation", "data", "opensearchDashboardsUtils"],
   "optionalPlugins": ["share"],
   "server": true,
-  "ui": true
+  "ui": true,
+  "configPath": ["opensearch_reporting"]
 }

--- a/dashboards-reports/server/config/config.ts
+++ b/dashboards-reports/server/config/config.ts
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  CoreSetup,
+  Logger,
+  PluginInitializerContext,
+} from '../../../../src/core/server';
+import { ReportingConfigType } from './schema';
+import { get } from 'lodash';
+import { first, map } from 'rxjs/operators';
+import { createConfig$ } from './createConfig';
+
+interface Config<BaseType> {
+  get<Key1 extends keyof BaseType>(key1: Key1): BaseType[Key1];
+  get<Key1 extends keyof BaseType, Key2 extends keyof BaseType[Key1]>(
+    key1: Key1,
+    key2: Key2
+  ): BaseType[Key1][Key2];
+}
+
+interface OsdServerConfigType {
+  server: {
+    basePath: string;
+    host: string;
+    name: string;
+    port: number;
+    protocol: string;
+  };
+}
+
+export interface ReportingConfig extends Config<ReportingConfigType> {
+  osdConfig: Config<OsdServerConfigType>;
+}
+
+export const buildConfig = async (
+  initContext: PluginInitializerContext<ReportingConfigType>,
+  core: CoreSetup,
+  logger: Logger
+): Promise<ReportingConfig> => {
+  const config$ = initContext.config.create<ReportingConfigType>();
+  const serverInfo = core.http.getServerInfo();
+  const osdConfig = {
+    server: {
+      basePath: core.http.basePath.serverBasePath,
+      host: serverInfo.hostname,
+      name: serverInfo.name,
+      port: serverInfo.port,
+      protocol: serverInfo.protocol,
+    },
+  };
+
+  const reportingConfig$ = createConfig$(core, config$, logger);
+  const reportingConfig = await reportingConfig$.pipe(first()).toPromise();
+  return {
+    get: (...keys: string[]) => get(reportingConfig, keys.join('.'), null),
+    osdConfig: {
+      get: (...keys: string[]) => get(osdConfig, keys.join('.'), null),
+    },
+  };
+};

--- a/dashboards-reports/server/config/createConfig.ts
+++ b/dashboards-reports/server/config/createConfig.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { CoreSetup, Logger } from '../../../../src/core/server';
+
+import { ReportingConfigType } from './schema';
+
+/*
+ * Set up dynamic config defaults
+ */
+export function createConfig$(
+  core: CoreSetup,
+  config$: Observable<ReportingConfigType>,
+  logger: Logger
+) {
+  return config$.pipe(
+    map((config) => {
+      const { osd_server: reportingServer } = config;
+      const serverInfo = core.http.getServerInfo();
+      // osd_server.hostname, default to server.host
+      const osdServerHostname = reportingServer.hostname
+        ? reportingServer.hostname
+        : serverInfo.hostname;
+
+      // osd_server.port, default to server.port
+      const osdServerPort = reportingServer.port
+        ? reportingServer.port
+        : serverInfo.port;
+      // osd_server.protocol, default to server.protocol
+      const osdServerProtocol = reportingServer.protocol
+        ? reportingServer.protocol
+        : serverInfo.protocol;
+      return {
+        ...config,
+        osd_server: {
+          hostname: osdServerHostname,
+          port: osdServerPort,
+          protocol: osdServerProtocol,
+        },
+      };
+    })
+  );
+}

--- a/dashboards-reports/server/config/index.ts
+++ b/dashboards-reports/server/config/index.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { PluginConfigDescriptor } from '../../../../src/core/server';
+import { ConfigSchema, ReportingConfigType } from './schema';
+export { buildConfig } from './config';
+export { ConfigSchema, ReportingConfigType };
+
+export const config: PluginConfigDescriptor<ReportingConfigType> = {
+  schema: ConfigSchema,
+};

--- a/dashboards-reports/server/config/schema.ts
+++ b/dashboards-reports/server/config/schema.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+const OsdServerSchema = schema.object({
+  hostname: schema.maybe(
+    schema.string({
+      validate(value) {
+        if (value === '0') {
+          return 'must not be "0" for the headless browser to correctly resolve the host';
+        }
+      },
+      hostname: true,
+    })
+  ),
+  port: schema.maybe(schema.number()),
+  protocol: schema.maybe(
+    schema.string({
+      validate(value) {
+        if (!/^https?$/.test(value)) {
+          return 'must be "http" or "https"';
+        }
+      },
+    })
+  ),
+}); // default values are all dynamic in createConfig$
+
+export const ConfigSchema = schema.object({
+  osd_server: OsdServerSchema,
+});
+
+export type ReportingConfigType = TypeOf<typeof ConfigSchema>;

--- a/dashboards-reports/server/index.ts
+++ b/dashboards-reports/server/index.ts
@@ -24,21 +24,19 @@
  * permissions and limitations under the License.
  */
 
-import {
-  HttpServerInfo,
-  PluginInitializerContext,
-} from '../../../src/core/server';
+import { PluginInitializerContext } from '../../../src/core/server';
+import { ReportingConfigType } from './config';
 import { ReportsDashboardsPlugin } from './plugin';
 
-export type AccessInfoType = {
-  basePath: string;
-  serverInfo: HttpServerInfo;
-};
+export { config } from './config';
+export { ReportingConfig } from './config/config';
+export { ReportsDashboardsPlugin as Plugin };
 
 //  This exports static code and TypeScript types,
 //  as well as, OpenSearch Dashboards Platform `plugin()` initializer.
-
-export function plugin(initializerContext: PluginInitializerContext) {
+export function plugin(
+  initializerContext: PluginInitializerContext<ReportingConfigType>
+) {
   return new ReportsDashboardsPlugin(initializerContext);
 }
 

--- a/dashboards-reports/server/routes/index.ts
+++ b/dashboards-reports/server/routes/index.ts
@@ -30,11 +30,11 @@ import registerReportSourceRoute from './reportSource';
 import registerMetricRoute from './metric';
 import registerNotificationRoute from './notifications';
 import { IRouter } from '../../../../src/core/server';
-import { AccessInfoType } from 'server';
+import { ReportingConfig } from 'server/config/config';
 
-export default function (router: IRouter, accessInfo: AccessInfoType) {
-  registerReportRoute(router, accessInfo);
-  registerReportDefinitionRoute(router, accessInfo);
+export default function (router: IRouter, config: ReportingConfig) {
+  registerReportRoute(router, config);
+  registerReportDefinitionRoute(router, config);
   registerReportSourceRoute(router);
   registerMetricRoute(router);
   registerNotificationRoute(router);

--- a/dashboards-reports/server/routes/lib/createReport.ts
+++ b/dashboards-reports/server/routes/lib/createReport.ts
@@ -46,14 +46,14 @@ import { SetCookie, Headers } from 'puppeteer-core';
 import { updateReportState } from './updateReportState';
 import { saveReport } from './saveReport';
 import { SemaphoreInterface } from 'async-mutex';
-import { AccessInfoType } from 'server';
+import { ReportingConfig } from 'server';
 import _ from 'lodash';
 
 export const createReport = async (
   request: OpenSearchDashboardsRequest,
   context: RequestHandlerContext,
   report: ReportSchemaType,
-  accessInfo: AccessInfoType,
+  config: ReportingConfig,
   savedReportId?: string
 ): Promise<CreateReportResultType> => {
   const isScheduledTask = false;
@@ -73,10 +73,10 @@ export const createReport = async (
     request.query.dateFormat || DATA_REPORT_CONFIG.excelDateFormat;
   // @ts-ignore
   const csvSeparator = request.query.csvSeparator || ',';
-  const {
-    basePath,
-    serverInfo: { protocol, port, hostname },
-  } = accessInfo;
+  const protocol = config.get('osd_server', 'protocol');
+  const hostname = config.get('osd_server', 'hostname');
+  const port = config.get('osd_server', 'port');
+  const basePath = config.osdConfig.get('server', 'basePath');
 
   let createReportResult: CreateReportResultType;
   let reportId;

--- a/dashboards-reports/server/routes/reportDefinition.ts
+++ b/dashboards-reports/server/routes/reportDefinition.ts
@@ -42,13 +42,14 @@ import { updateReportDefinition } from './lib/updateReportDefinition';
 import { DEFAULT_MAX_SIZE } from './utils/constants';
 import { addToMetric } from './utils/metricHelper';
 import { validateReportDefinition } from '../../server/utils/validationHelper';
-import { AccessInfoType } from 'server';
+import { ReportingConfig } from 'server';
 
-export default function (router: IRouter, accessInfo: AccessInfoType) {
-  const {
-    basePath,
-    serverInfo: { protocol, port, hostname },
-  } = accessInfo;
+export default function (router: IRouter, config: ReportingConfig) {
+  const protocol = config.get('osd_server', 'protocol');
+  const hostname = config.get('osd_server', 'hostname');
+  const port = config.get('osd_server', 'port');
+  const basePath = config.osdConfig.get('server', 'basePath');
+
   // Create report Definition
   router.post(
     {

--- a/dashboards-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
+++ b/dashboards-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
@@ -24,7 +24,7 @@
  * permissions and limitations under the License.
  */
 
-import { AccessInfoType } from 'server';
+import { ReportingConfig } from 'server/config/config';
 import {
   BackendReportInstanceType,
   BACKEND_DELIVERY_FORMAT,
@@ -83,19 +83,10 @@ const input: BackendReportInstanceType = {
   status: BACKEND_REPORT_STATE.success,
 };
 
-const testAccessInfo: AccessInfoType = {
-  basePath: '',
-  serverInfo: {
-    name: '',
-    hostname: 'localhost',
-    port: 5601,
-    protocol: 'http',
-  },
-};
+const sampleServerBasePath = '/test';
 
 const output = {
-  query_url:
-    "/app/dashboards#/view/722b74f0-b882-11e8-a6d9-e546fe2bba5f?_g=(time:(from:'2020-11-11T00:32:00.000Z',to:'2020-11-11T01:02:00.000Z'))",
+  query_url: `${sampleServerBasePath}/app/dashboards#/view/722b74f0-b882-11e8-a6d9-e546fe2bba5f?_g=(time:(from:'2020-11-11T00:32:00.000Z',to:'2020-11-11T01:02:00.000Z'))`,
   time_from: 1605054720000,
   time_to: 1605056520000,
   last_updated: 1605056644321,
@@ -107,7 +98,7 @@ const output = {
       report_source: 'Dashboard',
       description: 'some random',
       core_params: {
-        base_url: '/app/dashboards#/view/722b74f0-b882-11e8-a6d9-e546fe2bba5f',
+        base_url: `${sampleServerBasePath}/app/dashboards#/view/722b74f0-b882-11e8-a6d9-e546fe2bba5f`,
         report_format: 'pdf',
         header: '<p>test header</p>',
         footer: '<p>fake footer</p>',
@@ -141,7 +132,7 @@ const output = {
 
 describe('test backend to ui model conversion', () => {
   test('convert backend to ui report', async () => {
-    const res = backendToUiReport(input, testAccessInfo.basePath);
+    const res = backendToUiReport(input, sampleServerBasePath);
     expect(res).toEqual(output);
   }, 20000);
 });


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
Enable plugin config and add the following configurations, that can be set in `kibana.yml`
```
# opensearch_reporting.osd_server.port: 44
# opensearch_reporting.osd_server.hostname: 'something.com'
# opensearch_reporting.osd_server.protocol: 'https'
``` 

If not provided, it will fall back to use
```
server.hostname
server.port
server.protocol
```

### Issues Resolved
#215 

### TODO
- add documentation

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
