### PR TITLE
Hard-code OpenSearch dependency to 1.1.0

### DIFF
--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Add Chromium Binary to Reporting for Testing
         run: |
+          sudo apt update
           sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
           cd OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip 

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.md" "**/*.txt"
+          args: --accept=200,403,429  "./**/*.md" "./**/*.txt"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -30,7 +30,7 @@ import java.util.concurrent.Callable
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        opensearch_version = '1.1.0' // System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

In thinking about how to fix https://github.com/opensearch-project/opensearch-build/issues/1266 this is another alternative to https://github.com/opensearch-project/dashboards-reports/pull/249. Since there's no opensearch-min 1.1.1 the patch for dashboards-reports uses 1.1.0 build tools.

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/1266

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
