### PR TITLE
Add Cypress Case Coverage on Details Pages

### DIFF
--- a/dashboards-reports/.cypress/integration/01-create.spec.ts
+++ b/dashboards-reports/.cypress/integration/01-create.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { visitReportingLandingPage } from "../support/constants";
+import { visitReportingLandingPage } from "../support/utils";
 
 describe('Adding sample data', () => {
   it('Adds sample data', () => {

--- a/dashboards-reports/.cypress/integration/01-create.spec.ts
+++ b/dashboards-reports/.cypress/integration/01-create.spec.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { visitReportingLandingPage } from "../support/constants";
+
 describe('Adding sample data', () => {
   it('Adds sample data', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
@@ -194,14 +196,6 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 });
-
-function visitReportingLandingPage() {
-  cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);
-  cy.location('pathname', { timeout: 60000 }).should(
-    'include',
-    '/reports-dashboards'
-  );
-}
 
 function visitCreateReportDefinitionPage() {
   cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);

--- a/dashboards-reports/.cypress/integration/03-details.spec.ts
+++ b/dashboards-reports/.cypress/integration/03-details.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { visitReportingLandingPage } from "../support/constants";
+import { visitReportingLandingPage } from "../support/utils";
 
 describe('Cypress', () => {
   it('Visit report definition details page', () => {

--- a/dashboards-reports/.cypress/integration/03-details.spec.ts
+++ b/dashboards-reports/.cypress/integration/03-details.spec.ts
@@ -3,45 +3,109 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { visitReportingLandingPage } from "../support/constants";
+
 describe('Cypress', () => {
   it('Visit report definition details page', () => {
-    cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);
-    cy.location('pathname', { timeout: 60000 }).should(
-      'include',
-      '/reports-dashboards'
-    );
+    visitReportingLandingPage();
+    cy.wait(5000);
+    visitReportDefinitionDetailsPage();
+    verifyReportDefinitionDetailsURL();
+    verifyDeleteDefinitionButtonExists();
+    verifyGenerateReportFromFileFormatExists();
+  });
 
-    cy.wait(12500);
+  it('Go to edit report definition from report definition details', () => {
+    visitReportingLandingPage();
+    cy.wait(5000);
+    visitReportDefinitionDetailsPage();
+    verifyEditDefinitionButtonExists();
+    clickEditReportDefinitionButton();
+    verifyEditReportDefinitionURL();
+  });
 
-    cy.get('#reportDefinitionDetailsLink').first().click();
+  it('Verify report source URL on report definition details', () => {
+    visitReportingLandingPage();
+    cy.wait(5000);
+    visitReportDefinitionDetailsPage();
+    verifyReportDefinitionSourceURLExists();
+    
+  });
 
-    cy.url().should('include', 'report_definition_details');
-
-    cy.get('#deleteReportDefinitionButton').should('exist');
-
-    cy.get('#editReportDefinitionButton').should('exist');
-
-    if (cy.get('body').contains('Schedule details')) {
-      cy.wait(1000);
-      cy.get('#changeStatusFromDetailsButton').click();
-    } else {
-      cy.wait(1000);
-      cy.get('#generateReportFromDetailsButton').click();
-    }
-
-    cy.get('#deleteReportDefinitionButton').click();
+  it('Delete report definition from details page', () => {
+    visitReportingLandingPage();
+    cy.wait(5000);
+    visitReportDefinitionDetailsPage();
+    verifyDeleteDefinitionButtonExists();
+    deleteReportDefinition();
+    verifyDeleteSuccess();
   });
 
   it('Visit report details page', () => {
-    cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);
-    cy.location('pathname', { timeout: 60000 }).should(
-      'include',
-      '/reports-dashboards'
-    );
+    visitReportingLandingPage();
+    cy.wait(5000);
+    visitReportDetailsPage();
+    verifyReportDetailsURL();
+  });
 
-    cy.wait(12500);
-    cy.get('#reportDetailsLink').first().click();
-
-    cy.url().should('include', 'report_details');
+  it('Verify report source URL on report details', () => {
+    visitReportingLandingPage();
+    cy.wait(5000);
+    visitReportDetailsPage();
+    verifyReportDetailsSourceURLExists();
   });
 });
+
+function visitReportDefinitionDetailsPage() {
+  cy.get('#reportDefinitionDetailsLink').first().click();
+}
+
+function verifyReportDefinitionDetailsURL() {
+  cy.url().should('include', 'report_definition_details');
+}
+
+function verifyDeleteDefinitionButtonExists() {
+  cy.get('#deleteReportDefinitionButton').should('exist');
+}
+
+function verifyEditDefinitionButtonExists() {
+  cy.get('#editReportDefinitionButton').should('exist');
+}
+
+function clickEditReportDefinitionButton() {
+  cy.get('#editReportDefinitionButton').click({ force: true });
+}
+
+function verifyEditReportDefinitionURL() {
+  cy.url().should('include', 'edit');
+}
+
+function verifyReportDefinitionSourceURLExists() {
+  cy.get('#reportDefinitionSourceURL').should('exist');
+}
+
+function verifyReportDetailsSourceURLExists() {
+  cy.get('#reportDetailsSourceURL').should('exist');
+}
+
+function verifyGenerateReportFromFileFormatExists() {
+  cy.get('#generateReportFromDetailsFileFormat').should('exist');
+}
+
+function deleteReportDefinition() {
+  cy.get('#deleteReportDefinitionButton').click();
+  cy.wait(500);
+  cy.get('button.euiButton:nth-child(2)').click({ force: true });
+}
+
+function verifyDeleteSuccess() {
+  cy.get('#deleteReportDefinitionSuccessToast').should('exist');
+}
+
+function visitReportDetailsPage() {
+  cy.get('#reportDetailsLink').first().click();
+}
+
+function verifyReportDetailsURL() {
+  cy.url().should('include', 'report_details');
+}

--- a/dashboards-reports/.cypress/support/constants.js
+++ b/dashboards-reports/.cypress/support/constants.js
@@ -7,3 +7,11 @@ export const ADMIN_AUTH = {
   username: 'admin',
   password: 'admin',
 };
+
+export function visitReportingLandingPage() {
+  cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);
+  cy.location('pathname', { timeout: 60000 }).should(
+    'include',
+    '/reports-dashboards'
+  );
+}

--- a/dashboards-reports/.cypress/support/constants.js
+++ b/dashboards-reports/.cypress/support/constants.js
@@ -7,11 +7,3 @@ export const ADMIN_AUTH = {
   username: 'admin',
   password: 'admin',
 };
-
-export function visitReportingLandingPage() {
-  cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);
-  cy.location('pathname', { timeout: 60000 }).should(
-    'include',
-    '/reports-dashboards'
-  );
-}

--- a/dashboards-reports/.cypress/support/utils.js
+++ b/dashboards-reports/.cypress/support/utils.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function visitReportingLandingPage() {
+    cy.visit(`${Cypress.env('opensearchDashboards')}/app/reports-dashboards#/`);
+    cy.location('pathname', { timeout: 60000 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+  }

--- a/dashboards-reports/public/components/main/report_definition_details/__tests__/__snapshots__/report_definition_details.test.tsx.snap
+++ b/dashboards-reports/public/components/main/report_definition_details/__tests__/__snapshots__/report_definition_details.test.tsx.snap
@@ -200,6 +200,7 @@ exports[`<ReportDefinitionDetails /> panel render 5 hours recurring definition d
               <a
                 class="euiLink euiLink--primary"
                 href=""
+                id="reportDefinitionSourceURL"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -242,7 +243,7 @@ exports[`<ReportDefinitionDetails /> panel render 5 hours recurring definition d
             >
               <button
                 class="euiLink euiLink--primary"
-                id="generateReportFromDetailsButton"
+                id="generateReportFromDetailsFileFormat"
                 type="button"
               >
                 undefined 
@@ -592,6 +593,7 @@ exports[`<ReportDefinitionDetails /> panel render disabled daily definition, cli
               <a
                 class="euiLink euiLink--primary"
                 href=""
+                id="reportDefinitionSourceURL"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -634,7 +636,7 @@ exports[`<ReportDefinitionDetails /> panel render disabled daily definition, cli
             >
               <button
                 class="euiLink euiLink--primary"
-                id="generateReportFromDetailsButton"
+                id="generateReportFromDetailsFileFormat"
                 type="button"
               >
                 undefined 
@@ -984,6 +986,7 @@ exports[`<ReportDefinitionDetails /> panel render on demand definition details 1
               <a
                 class="euiLink euiLink--primary"
                 href=""
+                id="reportDefinitionSourceURL"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -1026,7 +1029,7 @@ exports[`<ReportDefinitionDetails /> panel render on demand definition details 1
             >
               <button
                 class="euiLink euiLink--primary"
-                id="generateReportFromDetailsButton"
+                id="generateReportFromDetailsFileFormat"
                 type="button"
               >
                 undefined 

--- a/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/dashboards-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -497,7 +497,7 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
     return (
       <EuiLink
         onClick={downloadIconDownload}
-        id="generateReportFromDetailsButton"
+        id="generateReportFromDetailsFileFormat"
       >
         {formatUpper + ' '}
         <EuiIcon type="importAction" />
@@ -507,7 +507,10 @@ export function ReportDefinitionDetails(props: { match?: any; setBreadcrumbs?: a
 
   const sourceURL = (data: ReportDefinitionDetails) => {
     return (
-      <EuiLink href={`${data.baseUrl}`} target="_blank">
+      <EuiLink
+        id="reportDefinitionSourceURL"
+        href={`${data.baseUrl}`} target="_blank"
+      >
         {data['source']}
       </EuiLink>
     );

--- a/dashboards-reports/public/components/main/report_details/__tests__/__snapshots__/report_details.test.tsx.snap
+++ b/dashboards-reports/public/components/main/report_details/__tests__/__snapshots__/report_details.test.tsx.snap
@@ -149,6 +149,7 @@ exports[`<ReportDetails /> panel render 5 hours recurring component 1`] = `
               <a
                 class="euiLink euiLink--primary"
                 href="http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))"
+                id="reportDetailsSourceURL"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -538,6 +539,7 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
               <a
                 class="euiLink euiLink--primary"
                 href="http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))"
+                id="reportDetailsSourceURL"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/dashboards-reports/public/components/main/report_details/report_details.tsx
+++ b/dashboards-reports/public/components/main/report_details/report_details.tsx
@@ -302,7 +302,10 @@ export function ReportDetails(props: { match?: any; setBreadcrumbs?: any; httpCl
 
   const sourceURL = (data: ReportDetails) => {
     return (
-      <EuiLink href={`${data.queryUrl}`} target="_blank">
+      <EuiLink
+        id="reportDetailsSourceURL"
+        href={`${data.queryUrl}`} target="_blank"
+      >
         {data['source']}
       </EuiLink>
     );


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
Add case coverage tests on Report definition details and Report details.
* Add test cases and extract cypress commands to functions in Report definition details and Report details
* Add `visitReportingLandingPage()` to constants.js 
* Added css selectors in Details pages

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
