### PR TITLE
[1.2] removing jcenter from gradle.build

### DIFF
--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -18,9 +18,9 @@ buildscript {
     }
 
     repositories {
+        mavenCentral()
         mavenLocal()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
-        mavenCentral()
     }
 
     dependencies {

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -18,16 +18,17 @@ buildscript {
     }
 
     repositories {
-        mavenCentral()
         mavenLocal()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.5"
     }
 }
@@ -112,9 +113,10 @@ allprojects {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
 }
 
 dependencies {

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.5"
     }
 }

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -112,6 +112,7 @@ allprojects {
 }
 
 repositories {
+    mavenCentral()
     mavenLocal()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -21,7 +21,6 @@ buildscript {
         mavenLocal()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
### Description
Build failure due to jcenter being in Reports-Scheduler. Detekt package was being used from jcenter repository. Maven Central just keeps the latest version of package as of now. Therefore, replaced jcenter with plugins.gradle to fetch the package of same version. 

### Issues Resolved
#276 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
