### PR TITLE
[main] remove jcenter repo from gradle build

### DIFF
--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -23,7 +23,6 @@ buildscript {
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        jcenter()
     }
 
     dependencies {
@@ -119,7 +118,6 @@ repositories {
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
### Description
Build failure due to jcenter being in Reports-Scheduler. Detekt package was being used from jcenter repository. Maven Central just keeps the latest version of package as of now. Therefore, replaced jcenter with plugins.gradle to fetch the package of same version. 

### Issues Resolved
#276 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
