### PR TITLE
Change Default CI version to JDK 11

### DIFF
--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -9,14 +9,16 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8, 11, 14, 17]
+        java:
+          - 11
+          - 14
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 1.11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: ${{ matrix.java }}
 
       # reports-scheduler
       - name: Checkout Reports Scheduler
@@ -33,8 +35,6 @@ jobs:
         run: |
           cd reports-scheduler
           ./gradlew build -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
-        with:
-          java-version: ${{ matrix.java }}
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -7,13 +7,17 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        java: [8, 11, 14, 17]
+
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 1.14
+      - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.14
+          java-version: 1.11
 
       # reports-scheduler
       - name: Checkout Reports Scheduler

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 14, 17]
-
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +33,8 @@ jobs:
         run: |
           cd reports-scheduler
           ./gradlew build -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/dashboards-reports/DEVELOPER_GUIDE.md
+++ b/dashboards-reports/DEVELOPER_GUIDE.md
@@ -2,6 +2,19 @@
 
 So you want to contribute code to this project? Excellent! We're glad you're here. Here's what you need to do.
 
+## Install Prerequisites
+
+### JDK 11
+
+OpenSearch builds using Java 11 at a minimum. This means you must have a JDK 11
+installed with the environment variable `JAVA_HOME` referencing the path to Java home
+for your JDK 11 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-11`.
+
+By default, tests use the same runtime as `JAVA_HOME`. However, since OpenSearch
+supports JDK 8, the build supports compiling with JDK 11 and testing on a different
+version of JDK runtime. To do this, set `RUNTIME_JAVA_HOME` pointing to the Java home of
+another JDK installation, e.g. `RUNTIME_JAVA_HOME=/usr/lib/jvm/jdk-8`.
+
 ## Setup
 
 1. Download OpenSearch for the version that matches the [OpenSearch Dashboards version specified in package.json](./package.json#L7).


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
* Change the default CI version for `reports-scheduler` workflow to JDK 11
* add JDK versions 11, 14 to CI matrix 
* Document Java version in DEVELOPER_GUIDE.md

Note: Java 8 and 17 will be added in a later  PR to resolve #230 

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
