### PR TITLE
changes regex to allow additional customized saved object ids

### DIFF
--- a/dashboards-reports/public/components/context_menu/context_menu.js
+++ b/dashboards-reports/public/components/context_menu/context_menu.js
@@ -125,10 +125,11 @@ const generateInContextReport = async (
     });
 };
 
-// try to match uuid followed by '?' in URL, which would be the saved search id for discover URL
+// try to match uuid and user entered custom-id followed by '?' in URL, which would be the saved search id for discover URL
+// custom id example: v1s-f00-b4r1-01
 const getUuidFromUrl = () =>
   window.location.href.match(
-    /(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)\?/
+    /([0-9a-z]+-[0-9a-z]+)+\?/
   );
 const isDiscover = () => window.location.href.includes('discover');
 


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
This code logic is contributed by @[inf17101](https://github.com/inf17101), in this #289. Since we need this fix to go out the upcoming release, and we decided to take the logic and commit,  instead of waiting for the author to reply

Better would be /(?:[0-9a-z]+-[0-9a-z]+)+?/ as regex expression because of non-capturing group.
Or to allow only a certain range of characters: /(?:/)([0-9a-z-]{1,100})?/



### Issues Resolved
#281 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
