### PR TITLE
Replace Centos links to fix link checker CI

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "./**/*.md" "./**/*.txt" --glob-ignore-case "https://centos.pkgs.org/7/*"
+          args: --accept=200,403,429  "./**/*.md" "./**/*.txt" --exclude "https://centos.pkgs.org/7/*"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,7 +16,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "./**/*.md" "./**/*.txt"
+          args: --accept=200,403,429  "./**/*.md" "./**/*.txt" --glob-ignore-case "https://centos.pkgs.org/7/*"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Chromium may not have all of the dependencies you may require to be able to view
 
 If you are using a CentOS/RHEL system, install the following packages:
 
-- [`ipa-gothic-fonts`](https://yum-info.contradodigital.com/view-package/base/ipa-gothic-fonts/)
-- [`xorg-x11-fonts-100dpi`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-100dpi/)
-- [`xorg-x11-fonts-75dpi`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-75dpi/)
-- [`xorg-x11-utils`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-utils/)
-- [`xorg-x11-fonts-cyrillic`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-cyrillic/)
-- [`xorg-x11-fonts-Type1`](https://yum-info.contradodigital.com/view-package/installed/xorg-x11-fonts-Type1/)
-- [`xorg-x11-fonts-misc`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-misc/)
+- [`ipa-gothic-fonts`](https://centos.pkgs.org/7/centos-x86_64/ipa-gothic-fonts-003.03-5.el7.noarch.rpm.html)
+- [`xorg-x11-fonts-100dpi`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-100dpi-7.5-9.el7.noarch.rpm.html)
+- [`xorg-x11-fonts-75dpi`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-75dpi-7.5-9.el7.noarch.rpm.html)
+- [`xorg-x11-utils`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-utils-7.5-23.el7.x86_64.rpm.html)
+- [`xorg-x11-fonts-cyrillic`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-cyrillic-7.5-9.el7.noarch.rpm.html)
+- [`xorg-x11-fonts-Type1`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-Type1-7.5-9.el7.noarch.rpm.html)
+- [`xorg-x11-fonts-misc`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-misc-7.5-9.el7.noarch.rpm.html)
 - [`fontconfig`](https://www.freedesktop.org/wiki/Software/fontconfig/)
 - [`freetype`](https://freetype.org/)
 

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Chromium may not have all of the dependencies you may require to be able to view
 
 If you are using a CentOS/RHEL system, install the following packages:
 
-- [`ipa-gothic-fonts`](https://centos.pkgs.org/7/centos-x86_64/ipa-gothic-fonts-003.03-5.el7.noarch.rpm.html)
-- [`xorg-x11-fonts-100dpi`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-100dpi-7.5-9.el7.noarch.rpm.html)
-- [`xorg-x11-fonts-75dpi`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-75dpi-7.5-9.el7.noarch.rpm.html)
-- [`xorg-x11-utils`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-utils-7.5-23.el7.x86_64.rpm.html)
-- [`xorg-x11-fonts-cyrillic`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-cyrillic-7.5-9.el7.noarch.rpm.html)
-- [`xorg-x11-fonts-Type1`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-Type1-7.5-9.el7.noarch.rpm.html)
-- [`xorg-x11-fonts-misc`](https://centos.pkgs.org/7/centos-x86_64/xorg-x11-fonts-misc-7.5-9.el7.noarch.rpm.html)
+- [`ipa-gothic-fonts`](https://yum-info.contradodigital.com/view-package/base/ipa-gothic-fonts/)
+- [`xorg-x11-fonts-100dpi`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-100dpi/)
+- [`xorg-x11-fonts-75dpi`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-75dpi/)
+- [`xorg-x11-utils`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-utils/)
+- [`xorg-x11-fonts-cyrillic`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-cyrillic/)
+- [`xorg-x11-fonts-Type1`](https://yum-info.contradodigital.com/view-package/installed/xorg-x11-fonts-Type1/)
+- [`xorg-x11-fonts-misc`](https://yum-info.contradodigital.com/view-package/base/xorg-x11-fonts-misc/)
 - [`fontconfig`](https://www.freedesktop.org/wiki/Software/fontconfig/)
 - [`freetype`](https://freetype.org/)
 


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
Exclude CentOS link from the link checker workflow to fix link checker workflow. All links from CentOS are accessible on browser but currently fail the workflow. 

### Issues Resolved
#296 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
