### PR TITLE
Add java 8 support in compile and test

### DIFF
--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         java:
+          - 8
           - 11
           - 14
     runs-on: ubuntu-latest

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -93,7 +93,7 @@ internal object PluginSettings {
 
     init {
         var settings: Settings? = null
-        val configDirName = BootstrapInfo.getSystemProperties()?.get("es.path.conf")?.toString()
+        val configDirName = BootstrapInfo.getSystemProperties()?.get("opensearch.path.conf")?.toString()
         if (configDirName != null) {
             val defaultSettingYmlFile = Paths.get(configDirName, PLUGIN_NAME, "reports-scheduler.yml")
             try {

--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -15,7 +15,7 @@ import org.opensearch.common.settings.Settings
 import org.opensearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
 import org.opensearch.reportsscheduler.ReportsSchedulerPlugin.Companion.PLUGIN_NAME
 import java.io.IOException
-import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * settings specific to reports scheduler Plugin.
@@ -95,7 +95,7 @@ internal object PluginSettings {
         var settings: Settings? = null
         val configDirName = BootstrapInfo.getSystemProperties()?.get("es.path.conf")?.toString()
         if (configDirName != null) {
-            val defaultSettingYmlFile = Path.of(configDirName, PLUGIN_NAME, "reports-scheduler.yml")
+            val defaultSettingYmlFile = Paths.get(configDirName, PLUGIN_NAME, "reports-scheduler.yml")
             try {
                 settings = Settings.builder().loadFromPath(defaultSettingYmlFile).build()
             } catch (exception: IOException) {

--- a/reports-scheduler/src/test/kotlin/org/opensearch/integTest/PluginRestTestCase.kt
+++ b/reports-scheduler/src/test/kotlin/org/opensearch/integTest/PluginRestTestCase.kt
@@ -39,7 +39,7 @@ import java.io.IOException
 import java.io.InputStreamReader
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file.Paths
 import java.security.cert.X509Certificate
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
@@ -265,7 +265,7 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
                     false
                 )
                 proxy.getExecutionData(false)?.let {
-                    val path = Path.of("$jacocoBuildPath/integTest.exec")
+                    val path = Paths.get("$jacocoBuildPath/integTest.exec")
                     Files.write(path, it)
                 }
             }


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
Replace `Path::of`(only works > java 11) with `Path::get`, to enable Java 8

### Issues Resolved
#230 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
