### PR TITLE
Change alpha1 to rc1 for first 2.0 release

### DIFF
--- a/dashboards-reports/opensearch_dashboards.json
+++ b/dashboards-reports/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "reportsDashboards",
-  "version": "2.0.0.0-alpha1",
+  "version": "2.0.0.0-rc1",
   "opensearchDashboardsVersion": "2.0.0",
   "requiredPlugins": ["navigation", "data", "opensearchDashboardsUtils"],
   "optionalPlugins": ["share"],

--- a/dashboards-reports/package.json
+++ b/dashboards-reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-dashboards",
-  "version": "2.0.0.0-alpha1",
+  "version": "2.0.0.0-rc1",
   "description": "OpenSearch Dashboards Reports Plugin",
   "license": "Apache-2.0",
   "main": "index.ts",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
rc1 will be used instead of alpha1, will send another PR to update for opensearch plugins when core is ready
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).