### PR TITLE
Remove JDK14 from CI

### DIFF
--- a/.github/workflows/reports-scheduler-release-workflow.yml
+++ b/.github/workflows/reports-scheduler-release-workflow.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Checkout Plugin
         uses: actions/checkout@v1
 
-      - name: Set up JDK 1.14
+      - name: Set up JDK 1.17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.14
+          java-version: 1.17
 
       - name: Run build
         run: |

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         java:
           - 11
-          - 14
           - 17
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Removing JDK14 from CI as we will be only supporting Java LTS versions(11&17) from 2.0 release.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
