### PR TITLE
Add Forum link in Dashboards reports plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ OpenSearch Dashboards Reports allows ‘Report Owner’ (engineers, including bu
 [nolabel-badge]: https://img.shields.io/github/issues-search/opensearch-project/dashboards-reports?color=yellow&label=no%20label%20issues&query=is%3Aopen%20is%3Aissue%20no%3Alabel
 [nolabel-link]: https://github.com/opensearch-project/dashboards-reports/issues?q=is%3Aopen+is%3Aissue+no%3Alabel+
 
-## Documentation
+## Documentation & Forum
 
-Please see our technical [documentation](https://opensearch.org/docs/dashboards/reporting/) to learn more about its features.
+Please see our technical [documentation](https://opensearch.org/docs/dashboards/reporting/) to learn more about its features. For additional help with the plugin, including questions about opening an issue, try the OpenSearch [Forum](https://forum.opensearch.org/c/opensearch-dashboards/reports/51).
 
 ## Contributing
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Added Forum information to the "Documentation" header section that includes verbiage and a link to the OpenSearch Forum page for Reporting.

### Issues Resolved
This more closely corresponds to the information found in the README.md file in all of the other plugins bundled with OpenSearch.

This fixes the issue for the Cross-cluster replication plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
