### PR TITLE
Backport to 1.3 for CVE Fix 1.3.6

### DIFF
--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)        
-        kotlin_version = System.getProperty("kotlin.version", "1.4.0")
+        kotlin_version = System.getProperty("kotlin.version", "1.6.0")
     }
 
     repositories {
@@ -30,7 +30,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
-        classpath "org.jacoco:org.jacoco.agent:0.8.5"
+        classpath "org.jacoco:org.jacoco.agent:0.8.7"
     }
 }
 
@@ -111,6 +111,7 @@ allprojects {
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
     }
+    jacoco.toolVersion = "0.8.7"
 }
 
 repositories {
@@ -130,7 +131,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     compile "org.json:json:20180813"
     compile group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
-    implementation 'org.jsoup:jsoup:1.14.3'
+    implementation 'org.jsoup:jsoup:1.15.3'
 
     testImplementation(
             'org.assertj:assertj-core:3.16.1',


### PR DESCRIPTION
Updating Kotlin and Jsoup

(cherry picked from commit 50eac1732041e7a5a7bb0e3fbaa26c4858f4f940)

### Description
CVE 1.3.6, updated Kotlin to 1.6.0 and Jsoup to 1.15.3. #472 

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
