### PR TITLE
Fix snakeyaml vulnerability issue by disabling detekt

### DIFF
--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -40,7 +40,7 @@ buildscript {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
+        // classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.5"
     }
 }
@@ -57,7 +57,7 @@ apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.testclusters'
-apply plugin: 'io.gitlab.arturbosch.detekt'
+// apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 
@@ -107,10 +107,11 @@ configurations {
     testRuntime
 }
 
-detekt {
+// TODO: enable detekt when snakeyaml vulnerability is fixed
+/*detekt {
     config = files("detekt.yml")
     buildUponDefaultConfig = true
-}
+}*/
 
 configurations.testCompile {
     exclude module: "securemock"

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -40,7 +40,6 @@ buildscript {
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        // classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
         classpath "org.jacoco:org.jacoco.agent:0.8.5"
     }
 }
@@ -57,7 +56,6 @@ apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.testclusters'
-// apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 
@@ -106,12 +104,6 @@ configurations {
     testCompile
     testRuntime
 }
-
-// TODO: enable detekt when snakeyaml vulnerability is fixed
-/*detekt {
-    config = files("detekt.yml")
-    buildUponDefaultConfig = true
-}*/
 
 configurations.testCompile {
     exclude module: "securemock"


### PR DESCRIPTION
Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
Disabling detekt 

### Issues Resolved
[CVE-2022-38749](https://nvd.nist.gov/vuln/detail/CVE-2022-38749)
[CVE-2022-38750](https://nvd.nist.gov/vuln/detail/CVE-2022-38750)
[CVE-2022-38751](https://nvd.nist.gov/vuln/detail/CVE-2022-38751)
[CVE-2022-38752](https://nvd.nist.gov/vuln/detail/CVE-2022-38752)
[CVE-2022-25857](https://nvd.nist.gov/vuln/detail/CVE-2022-25857)
[CVE-2022-0272](https://nvd.nist.gov/vuln/detail/CVE-2022-0272)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
