### PR TITLE
Fix metrics tests and ClassNotFoundException when calling stats API

### DIFF
--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -164,7 +164,11 @@ dependencies {
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation "org.json:json:20180813"
-    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
+    // json-base, jackson-databind, jackson-annotations are transitive dependencies by json-flattener
+    implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.4"
     implementation 'org.jsoup:jsoup:1.15.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
@@ -174,11 +178,12 @@ dependencies {
             'org.junit.jupiter:junit-jupiter-api:5.6.2'
     )
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
-    testCompile "org.opensearch.test:framework:${opensearch_version}"
-    testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
+    testImplementation "org.opensearch.test:framework:${opensearch_version}"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testCompile "org.mockito:mockito-core:3.12.4"
-    testCompile 'com.google.code.gson:gson:2.8.9'
+    testImplementation "org.mockito:mockito-core:4.7.0"
+    testImplementation "org.mockito:mockito-junit-jupiter:4.7.0"
+    testImplementation 'com.google.code.gson:gson:2.8.9'
 
     ktlint "com.pinterest:ktlint:0.45.1"
 }

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -25,8 +25,9 @@ buildscript {
         }
 
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
-        job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)        
+        job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.6.0")
+        jackson_version = "2.14.1"
     }
 
     repositories {
@@ -167,8 +168,8 @@ dependencies {
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
     // json-base, jackson-databind, jackson-annotations are transitive dependencies by json-flattener
     implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.4"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     implementation 'org.jsoup:jsoup:1.15.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/reports-scheduler/src/test/java/org/opensearch/reportsscheduler/metrics/BasicCounterTests.java
+++ b/reports-scheduler/src/test/java/org/opensearch/reportsscheduler/metrics/BasicCounterTests.java
@@ -5,17 +5,17 @@
 
 package org.opensearch.reportsscheduler.metrics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-public class BasicCounterTest {
+public class BasicCounterTests {
 
     @Test
     public void increment() {
         BasicCounter counter = new BasicCounter();
-        for (int i=0; i<5; ++i) {
+        for (int i = 0; i < 5; ++i) {
             counter.increment();
         }
 

--- a/reports-scheduler/src/test/java/org/opensearch/reportsscheduler/metrics/RollingCounterTests.java
+++ b/reports-scheduler/src/test/java/org/opensearch/reportsscheduler/metrics/RollingCounterTests.java
@@ -4,10 +4,11 @@
  */
 
 package org.opensearch.reportsscheduler.metrics;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
 
@@ -16,8 +17,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class RollingCounterTest {
+@ExtendWith(MockitoExtension.class)
+public class RollingCounterTests {
 
     @Mock
     Clock clock;
@@ -25,7 +26,7 @@ public class RollingCounterTest {
     @Test
     public void increment() {
         RollingCounter counter = new RollingCounter(3, 1, clock);
-        for (int i=0; i<5; ++i) {
+        for (int i = 0; i < 5; ++i) {
             counter.increment();
         }
 
@@ -67,7 +68,7 @@ public class RollingCounterTest {
     public void trim() {
         RollingCounter counter = new RollingCounter(2, 1, clock);
 
-        for (int i=1; i<6; ++i) {
+        for (int i = 1; i < 6; ++i) {
             counter.increment();
             assertThat(counter.size(), equalTo(i));
             when(clock.millis()).thenReturn(i * 1000L); // i seconds passed


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Calling `GET /_plugins/_reports/_local/stats` would crash OpenSearch with `ClassNotFoundException`. 

```
[2022-11-29T00:53:06,489][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [dev-dsk-lijshu-2b-daaa4402.us-west-2.amazon.com] fatal error in thread [Thread-3], exiting
java.lang.NoClassDefFoundError: com/eclipsesource/json/JsonValue
        at org.opensearch.reportsscheduler.metrics.Metrics.collectToFlattenedJSON(Metrics.java:184) ~[?:?]
        at org.opensearch.reportsscheduler.resthandler.ReportStatsRestHandler.prepareRequest$lambda-0(ReportStatsRestHandler.kt:78) ~[?:?]
```

This is because for some reason OpenSearch plugins don't resolve indirect dependencies of com.github.wnameless.json:json-flattener, I had to manually add them to build.gradle:
```groovy
  implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
  implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4"
  implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.4"
```

This PR also addresses tests issues (they were not running and were not passing previously).

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
