### PR TITLE
Use advanced settings for leading wildcards in query for csv reports

### DIFF
--- a/dashboards-reports/public/components/utils/settings_service.ts
+++ b/dashboards-reports/public/components/utils/settings_service.ts
@@ -22,10 +22,12 @@ export const uiSettingsService = {
         : rawTimeZone;
     const dateFormat = this.get('dateFormat');
     const csvSeparator = this.get('csv:separator');
+    const allowLeadingWildcards = this.get('query:allowLeadingWildcards');
     return {
       timezone,
       dateFormat,
       csvSeparator,
+      allowLeadingWildcards,
     };
   },
 };

--- a/dashboards-reports/server/routes/lib/createReport.ts
+++ b/dashboards-reports/server/routes/lib/createReport.ts
@@ -49,7 +49,7 @@ export const createReport = async (
   // @ts-ignore
   const csvSeparator = request.query.csvSeparator || ',';
   // @ts-ignore
-  const allowLeadingWildcards = request.query.allowLeadingWildcards;
+  const allowLeadingWildcards = !!request.query.allowLeadingWildcards;
 
   const protocol = config.get('osd_server', 'protocol');
   const hostname = config.get('osd_server', 'hostname');

--- a/dashboards-reports/server/routes/lib/createReport.ts
+++ b/dashboards-reports/server/routes/lib/createReport.ts
@@ -48,6 +48,9 @@ export const createReport = async (
     request.query.dateFormat || DATA_REPORT_CONFIG.excelDateFormat;
   // @ts-ignore
   const csvSeparator = request.query.csvSeparator || ',';
+  // @ts-ignore
+  const allowLeadingWildcards = request.query.allowLeadingWildcards;
+
   const protocol = config.get('osd_server', 'protocol');
   const hostname = config.get('osd_server', 'hostname');
   const port = config.get('osd_server', 'port');
@@ -76,6 +79,7 @@ export const createReport = async (
         opensearchClient,
         dateFormat,
         csvSeparator,
+        allowLeadingWildcards,
         isScheduledTask,
         logger
       );

--- a/dashboards-reports/server/routes/report.ts
+++ b/dashboards-reports/server/routes/report.ts
@@ -38,6 +38,7 @@ export default function (router: IRouter, config: ReportingConfig) {
           timezone: schema.maybe(schema.string()),
           dateFormat: schema.maybe(schema.string()),
           csvSeparator: schema.maybe(schema.string()),
+          allowLeadingWildcards: schema.maybe(schema.string()),
         }),
       },
     },
@@ -66,7 +67,6 @@ export default function (router: IRouter, config: ReportingConfig) {
 
       try {
         const reportData = await createReport(request, context, report, config);
-
         // if not deliver to user himself , no need to send actual file data to client
         const delivery = report.report_definition.delivery;
         addToMetric('report', 'create', 'count', report);
@@ -98,6 +98,7 @@ export default function (router: IRouter, config: ReportingConfig) {
           timezone: schema.string(),
           dateFormat: schema.string(),
           csvSeparator: schema.string(),
+          allowLeadingWildcards: schema.string(),
         }),
       },
     },
@@ -164,6 +165,7 @@ export default function (router: IRouter, config: ReportingConfig) {
           timezone: schema.string(),
           dateFormat: schema.string(),
           csvSeparator: schema.string(),
+          allowLeadingWildcards: schema.string(),
         }),
       },
     },

--- a/dashboards-reports/server/routes/report.ts
+++ b/dashboards-reports/server/routes/report.ts
@@ -67,7 +67,7 @@ export default function (router: IRouter, config: ReportingConfig) {
 
       try {
         const reportData = await createReport(request, context, report, config);
-        
+
         // if not deliver to user himself , no need to send actual file data to client
         const delivery = report.report_definition.delivery;
         addToMetric('report', 'create', 'count', report);

--- a/dashboards-reports/server/routes/report.ts
+++ b/dashboards-reports/server/routes/report.ts
@@ -67,6 +67,7 @@ export default function (router: IRouter, config: ReportingConfig) {
 
       try {
         const reportData = await createReport(request, context, report, config);
+        
         // if not deliver to user himself , no need to send actual file data to client
         const delivery = report.report_definition.delivery;
         addToMetric('report', 'create', 'count', report);

--- a/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/dashboards-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -64,6 +64,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -76,6 +77,7 @@ describe('test create saved search report', () => {
       mockOpenSearchClient([]),
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -87,6 +89,7 @@ describe('test create saved search report', () => {
       mockOpenSearchClient([]),
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -101,6 +104,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -121,6 +125,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -155,6 +160,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -192,6 +198,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -221,6 +228,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -254,6 +262,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -281,6 +290,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -305,6 +315,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       '|',
+      true,
       undefined,
       mockLogger
     );
@@ -338,6 +349,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -363,6 +375,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -394,6 +407,7 @@ describe('test create saved search report', () => {
       client,
       mockDateFormat,
       ',',
+      true,
       undefined,
       mockLogger
     );
@@ -421,6 +435,7 @@ test('create report for data set contains null field value', async () => {
     client,
     mockDateFormat,
     ',',
+    true,
     undefined,
     mockLogger
   );
@@ -452,6 +467,7 @@ test('create report for data set with metadata fields', async () => {
     client,
     mockDateFormat,
     ',',
+    true,
     undefined,
     mockLogger
   );
@@ -506,6 +522,7 @@ test('create report with empty/one/multiple(list) date values', async () => {
     client,
     mockDateFormat,
     ',',
+    true,
     undefined,
     mockLogger
   );

--- a/dashboards-reports/server/routes/utils/dataReportHelpers.ts
+++ b/dashboards-reports/server/routes/utils/dataReportHelpers.ts
@@ -55,7 +55,7 @@ export const buildRequestBody = (report: any, allowLeadingWildcards: boolean, is
   const searchSourceJSON = report._source.searchSourceJSON;
   const savedObjectQuery: Query = JSON.parse(searchSourceJSON).query;
   const savedObjectFilter: Filter = JSON.parse(searchSourceJSON).filter;
-  const config: OpenSearchQueryConfig = {
+  const savedObjectConfig: OpenSearchQueryConfig = {
     allowLeadingWildcards: allowLeadingWildcards,
     queryStringOptions: {},
     ignoreFilterIfFieldNotInIndex: false,
@@ -64,7 +64,7 @@ export const buildRequestBody = (report: any, allowLeadingWildcards: boolean, is
     undefined,
     savedObjectQuery,
     savedObjectFilter,
-    config
+    savedObjectConfig,
   );
   // Add time range
   if (report._source.timeFieldName && report._source.timeFieldName.length > 0) {

--- a/dashboards-reports/server/routes/utils/dataReportHelpers.ts
+++ b/dashboards-reports/server/routes/utils/dataReportHelpers.ts
@@ -12,6 +12,7 @@ import {
   buildOpenSearchQuery,
   Filter,
   Query,
+  OpenSearchQueryConfig,
 } from '../../../../../src/plugins/data/common';
 
 export var metaData = {
@@ -49,16 +50,21 @@ export const getSelectedFields = async (columns) => {
 
 // Build the OpenSearch query from the meta data
 // is_count is set to 1 if we building the count query but 0 if we building the fetch data query
-export const buildRequestBody = (report: any, is_count: number) => {
+export const buildRequestBody = (report: any, allowLeadingWildcards: boolean, is_count: number) => {
   let esbBoolQuery = esb.boolQuery();
   const searchSourceJSON = report._source.searchSourceJSON;
-
   const savedObjectQuery: Query = JSON.parse(searchSourceJSON).query;
   const savedObjectFilter: Filter = JSON.parse(searchSourceJSON).filter;
+  const config: OpenSearchQueryConfig = {
+    allowLeadingWildcards: allowLeadingWildcards,
+    queryStringOptions: {},
+    ignoreFilterIfFieldNotInIndex: false,
+  }
   const QueryFromSavedObject = buildOpenSearchQuery(
     undefined,
     savedObjectQuery,
-    savedObjectFilter
+    savedObjectFilter,
+    config
   );
   // Add time range
   if (report._source.timeFieldName && report._source.timeFieldName.length > 0) {

--- a/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -30,6 +30,7 @@ export async function createSavedSearchReport(
   client: ILegacyClusterClient | ILegacyScopedClusterClient,
   dateFormat: string,
   csvSeparator: string,
+  allowLeadingWildcards: boolean,
   isScheduledTask: boolean = true,
   logger: Logger
 ): Promise<CreateReportResultType> {
@@ -43,6 +44,7 @@ export async function createSavedSearchReport(
     params.core_params,
     dateFormat,
     csvSeparator,
+    allowLeadingWildcards,
     isScheduledTask,
     logger
   );
@@ -130,6 +132,7 @@ async function generateReportData(
   params: any,
   dateFormat: string,
   csvSeparator: string,
+  allowLeadingWildcards: boolean,
   isScheduledTask: boolean,
   logger: Logger
 ) {
@@ -144,8 +147,7 @@ async function generateReportData(
   if (total === 0) {
     return '';
   }
-
-  const reqBody = buildRequestBody(report, 0);
+  const reqBody = buildRequestBody(report, allowLeadingWildcards, 0);
   logger.info(
     `[Reporting csv module] DSL request body: ${JSON.stringify(reqBody)}`
   );
@@ -182,7 +184,7 @@ async function generateReportData(
 
   // Build the OpenSearch Count query to count the size of result
   async function getOpenSearchDataSize() {
-    const countReq = buildRequestBody(report, 1);
+    const countReq = buildRequestBody(report, allowLeadingWildcards, 1);
     return await callCluster(
       client,
       'count',

--- a/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -147,6 +147,7 @@ async function generateReportData(
   if (total === 0) {
     return '';
   }
+  
   const reqBody = buildRequestBody(report, allowLeadingWildcards, 0);
   logger.info(
     `[Reporting csv module] DSL request body: ${JSON.stringify(reqBody)}`

--- a/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/dashboards-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -147,7 +147,7 @@ async function generateReportData(
   if (total === 0) {
     return '';
   }
-  
+
   const reqBody = buildRequestBody(report, allowLeadingWildcards, 0);
   logger.info(
     `[Reporting csv module] DSL request body: ${JSON.stringify(reqBody)}`


### PR DESCRIPTION
### Description
- use allowLeadingWildcards in ui settings for csv reports

### Issues Resolved
https://github.com/opensearch-project/dashboards-reports/issues/299

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
