### PR TITLE
Resolve conflicting dependencies

### DIFF
--- a/dashboards-reports/package.json
+++ b/dashboards-reports/package.json
@@ -45,7 +45,6 @@
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jsdom": "^16.2.3",
     "@types/puppeteer-core": "^5.4.0",
-    "@types/react": "^16.9.36",
     "@types/react-addons-test-utils": "^0.14.25",
     "@types/react-dom": "^16.9.8",
     "@types/react-test-renderer": "^16.9.1",

--- a/dashboards-reports/yarn.lock
+++ b/dashboards-reports/yarn.lock
@@ -696,7 +696,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.36":
+"@types/react@*":
   version "16.9.49"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
   integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==


### PR DESCRIPTION
Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
Resolve conflicting dependencies

### Issues Resolved
`yarn osd bootstrap` failed with error 
```
ERROR [single_version_dependencies] Multiple version ranges for the same dependency
      were found declared across different package.json files. Please consolidate
      those to match across all package.json files. Different versions for the
      same dependency is not supported.

      If you have questions about this please reach out to the operations team.

      The conflicting dependencies are:

        @types/react
          ^16.14.23 => opensearch-dashboards
          ^16.9.36 => reports-dashboards
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
