### PR TITLE
Pull Job scheduler from maven instead of jenkins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,8 +329,8 @@ String baseVersion = "2.7.0"
 String bwcVersion = baseVersion + ".0"
 String baseName = "reportsSchedulerBwcCluster"
 String bwcFilePath = "src/test/resources/bwc"
-String bwcJobSchedulerURL = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${baseVersion}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-${bwcVersion}.zip"
-String bwcReportsSchedulerURL = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${baseVersion}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-reports-scheduler-${bwcVersion}.zip"
+String bwcJobSchedulerURL = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-job-scheduler/2.7.0.0-SNAPSHOT/opensearch-job-scheduler-2.7.0.0-20230305.020625-11.zip"
+String bwcReportsSchedulerURL = "https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/opensearch-reports-scheduler/2.7.0.0-SNAPSHOT/opensearch-reports-scheduler-2.7.0.0-20230306.195720-1.zip"
 
 2.times {i ->
     testClusters {


### PR DESCRIPTION
### Description
Pull Job scheduler from maven instead of jenkins to unblock main pipeline using stale snapshots

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
