### PR TITLE
Upgrade ktlint to ktlint-cli 1.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,7 +258,7 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"
     testImplementation 'com.google.code.gson:gson:2.8.9'
 
-    ktlint "com.pinterest:ktlint:0.47.1"
+    ktlint "com.pinterest.ktlint:ktlint-cli:1.8.0"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
@@ -62,8 +62,11 @@ import java.util.function.Supplier
  * Entry point of the OpenSearch Reports scheduler plugin.
  * This class initializes the rest handlers.
  */
-class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSchedulerExtension {
-
+class ReportsSchedulerPlugin :
+    Plugin(),
+    ActionPlugin,
+    SystemIndexPlugin,
+    JobSchedulerExtension {
     companion object {
         const val PLUGIN_NAME = "opensearch-reports-scheduler"
         const val LOG_PREFIX = "reports"
@@ -80,12 +83,11 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
         return settingList
     }
 
-    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
-        return listOf(
+    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> =
+        listOf(
             SystemIndexDescriptor(REPORT_DEFINITIONS_INDEX_NAME, "Reports Scheduler Plugin Definitions index"),
-            SystemIndexDescriptor(REPORT_INSTANCES_INDEX_NAME, "Reports Scheduler Plugin Instances index")
+            SystemIndexDescriptor(REPORT_INSTANCES_INDEX_NAME, "Reports Scheduler Plugin Instances index"),
         )
-    }
 
     /**
      * {@inheritDoc}
@@ -101,7 +103,7 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
         nodeEnvironment: NodeEnvironment,
         namedWriteableRegistry: NamedWriteableRegistry,
         indexNameExpressionResolver: IndexNameExpressionResolver,
-        repositoriesServiceSupplier: Supplier<RepositoriesService>
+        repositoriesServiceSupplier: Supplier<RepositoriesService>,
     ): Collection<Any> {
         PluginSettings.addSettingsUpdateConsumer(clusterService)
         ReportDefinitionsIndex.initialize(client, clusterService)
@@ -112,30 +114,22 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
     /**
      * {@inheritDoc}
      */
-    override fun getJobType(): String {
-        return "reports-scheduler"
-    }
+    override fun getJobType(): String = "reports-scheduler"
 
     /**
      * {@inheritDoc}
      */
-    override fun getJobIndex(): String {
-        return REPORT_DEFINITIONS_INDEX_NAME
-    }
+    override fun getJobIndex(): String = REPORT_DEFINITIONS_INDEX_NAME
 
     /**
      * {@inheritDoc}
      */
-    override fun getJobRunner(): ScheduledJobRunner {
-        return ReportDefinitionJobRunner
-    }
+    override fun getJobRunner(): ScheduledJobRunner = ReportDefinitionJobRunner
 
     /**
      * {@inheritDoc}
      */
-    override fun getJobParser(): ScheduledJobParser {
-        return ReportDefinitionJobParser
-    }
+    override fun getJobParser(): ScheduledJobParser = ReportDefinitionJobParser
 
     /**
      * {@inheritDoc}
@@ -147,23 +141,22 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
         indexScopedSettings: IndexScopedSettings,
         settingsFilter: SettingsFilter,
         indexNameExpressionResolver: IndexNameExpressionResolver,
-        nodesInCluster: Supplier<DiscoveryNodes>
-    ): List<RestHandler> {
-        return listOf(
+        nodesInCluster: Supplier<DiscoveryNodes>,
+    ): List<RestHandler> =
+        listOf(
             ReportDefinitionRestHandler(),
             ReportDefinitionListRestHandler(),
             ReportInstanceRestHandler(),
             ReportInstanceListRestHandler(),
             OnDemandReportRestHandler(),
-            ReportStatsRestHandler()
+            ReportStatsRestHandler(),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> {
-        return listOf(
+    override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> =
+        listOf(
             ActionPlugin.ActionHandler(CreateReportDefinitionAction.ACTION_TYPE, CreateReportDefinitionAction::class.java),
             ActionPlugin.ActionHandler(DeleteReportDefinitionAction.ACTION_TYPE, DeleteReportDefinitionAction::class.java),
             ActionPlugin.ActionHandler(GetAllReportDefinitionsAction.ACTION_TYPE, GetAllReportDefinitionsAction::class.java),
@@ -173,7 +166,6 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
             ActionPlugin.ActionHandler(InContextReportCreateAction.ACTION_TYPE, InContextReportCreateAction::class.java),
             ActionPlugin.ActionHandler(OnDemandReportCreateAction.ACTION_TYPE, OnDemandReportCreateAction::class.java),
             ActionPlugin.ActionHandler(UpdateReportDefinitionAction.ACTION_TYPE, UpdateReportDefinitionAction::class.java),
-            ActionPlugin.ActionHandler(UpdateReportInstanceStatusAction.ACTION_TYPE, UpdateReportInstanceStatusAction::class.java)
+            ActionPlugin.ActionHandler(UpdateReportInstanceStatusAction.ACTION_TYPE, UpdateReportInstanceStatusAction::class.java),
         )
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/CreateReportDefinitionAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/CreateReportDefinitionAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Create reportDefinition transport action
  */
-internal class CreateReportDefinitionAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<CreateReportDefinitionRequest, CreateReportDefinitionResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::CreateReportDefinitionRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/create"
-        internal val ACTION_TYPE = ActionType(NAME, ::CreateReportDefinitionResponse)
-    }
+internal class CreateReportDefinitionAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<CreateReportDefinitionRequest, CreateReportDefinitionResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::CreateReportDefinitionRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/definition/create"
+            internal val ACTION_TYPE = ActionType(NAME, ::CreateReportDefinitionResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: CreateReportDefinitionRequest, user: User?): CreateReportDefinitionResponse {
-        return ReportDefinitionActions.create(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: CreateReportDefinitionRequest,
+            user: User?,
+        ): CreateReportDefinitionResponse = ReportDefinitionActions.create(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/DeleteReportDefinitionAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/DeleteReportDefinitionAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Delete reportDefinition transport action
  */
-internal class DeleteReportDefinitionAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<DeleteReportDefinitionRequest, DeleteReportDefinitionResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::DeleteReportDefinitionRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/delete"
-        internal val ACTION_TYPE = ActionType(NAME, ::DeleteReportDefinitionResponse)
-    }
+internal class DeleteReportDefinitionAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<DeleteReportDefinitionRequest, DeleteReportDefinitionResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::DeleteReportDefinitionRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/definition/delete"
+            internal val ACTION_TYPE = ActionType(NAME, ::DeleteReportDefinitionResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: DeleteReportDefinitionRequest, user: User?): DeleteReportDefinitionResponse {
-        return ReportDefinitionActions.delete(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: DeleteReportDefinitionRequest,
+            user: User?,
+        ): DeleteReportDefinitionResponse = ReportDefinitionActions.delete(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportDefinitionsAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportDefinitionsAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Get all reportDefinitions transport action
  */
-internal class GetAllReportDefinitionsAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<GetAllReportDefinitionsRequest, GetAllReportDefinitionsResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::GetAllReportDefinitionsRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/list"
-        internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportDefinitionsResponse)
-    }
+internal class GetAllReportDefinitionsAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<GetAllReportDefinitionsRequest, GetAllReportDefinitionsResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::GetAllReportDefinitionsRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/definition/list"
+            internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportDefinitionsResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: GetAllReportDefinitionsRequest, user: User?): GetAllReportDefinitionsResponse {
-        return ReportDefinitionActions.getAll(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: GetAllReportDefinitionsRequest,
+            user: User?,
+        ): GetAllReportDefinitionsResponse = ReportDefinitionActions.getAll(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportInstancesAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/GetAllReportInstancesAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Get all report instances transport action
  */
-internal class GetAllReportInstancesAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<GetAllReportInstancesRequest, GetAllReportInstancesResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::GetAllReportInstancesRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/instance/list"
-        internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportInstancesResponse)
-    }
+internal class GetAllReportInstancesAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<GetAllReportInstancesRequest, GetAllReportInstancesResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::GetAllReportInstancesRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/instance/list"
+            internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportInstancesResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: GetAllReportInstancesRequest, user: User?): GetAllReportInstancesResponse {
-        return ReportInstanceActions.getAll(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: GetAllReportInstancesRequest,
+            user: User?,
+        ): GetAllReportInstancesResponse = ReportInstanceActions.getAll(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportDefinitionAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportDefinitionAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Get reportDefinition transport action
  */
-internal class GetReportDefinitionAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<GetReportDefinitionRequest, GetReportDefinitionResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::GetReportDefinitionRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/get"
-        internal val ACTION_TYPE = ActionType(NAME, ::GetReportDefinitionResponse)
-    }
+internal class GetReportDefinitionAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<GetReportDefinitionRequest, GetReportDefinitionResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::GetReportDefinitionRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/definition/get"
+            internal val ACTION_TYPE = ActionType(NAME, ::GetReportDefinitionResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: GetReportDefinitionRequest, user: User?): GetReportDefinitionResponse {
-        return ReportDefinitionActions.info(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: GetReportDefinitionRequest,
+            user: User?,
+        ): GetReportDefinitionResponse = ReportDefinitionActions.info(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportInstanceAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/GetReportInstanceAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Get report instance transport action
  */
-internal class GetReportInstanceAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<GetReportInstanceRequest, GetReportInstanceResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::GetReportInstanceRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/instance/get"
-        internal val ACTION_TYPE = ActionType(NAME, ::GetReportInstanceResponse)
-    }
+internal class GetReportInstanceAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<GetReportInstanceRequest, GetReportInstanceResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::GetReportInstanceRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/instance/get"
+            internal val ACTION_TYPE = ActionType(NAME, ::GetReportInstanceResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: GetReportInstanceRequest, user: User?): GetReportInstanceResponse {
-        return ReportInstanceActions.info(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: GetReportInstanceRequest,
+            user: User?,
+        ): GetReportInstanceResponse = ReportInstanceActions.info(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/InContextReportCreateAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/InContextReportCreateAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * In-Context ReportCreate transport action
  */
-internal class InContextReportCreateAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<InContextReportCreateRequest, InContextReportCreateResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::InContextReportCreateRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/menu/download"
-        internal val ACTION_TYPE = ActionType(NAME, ::InContextReportCreateResponse)
-    }
+internal class InContextReportCreateAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<InContextReportCreateRequest, InContextReportCreateResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::InContextReportCreateRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/menu/download"
+            internal val ACTION_TYPE = ActionType(NAME, ::InContextReportCreateResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: InContextReportCreateRequest, user: User?): InContextReportCreateResponse {
-        return ReportInstanceActions.createOnDemand(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: InContextReportCreateRequest,
+            user: User?,
+        ): InContextReportCreateResponse = ReportInstanceActions.createOnDemand(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/OnDemandReportCreateAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/OnDemandReportCreateAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * On-Demand ReportCreate transport action
  */
-internal class OnDemandReportCreateAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<OnDemandReportCreateRequest, OnDemandReportCreateResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::OnDemandReportCreateRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/on_demand"
-        internal val ACTION_TYPE = ActionType(NAME, ::OnDemandReportCreateResponse)
-    }
+internal class OnDemandReportCreateAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<OnDemandReportCreateRequest, OnDemandReportCreateResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::OnDemandReportCreateRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/definition/on_demand"
+            internal val ACTION_TYPE = ActionType(NAME, ::OnDemandReportCreateResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: OnDemandReportCreateRequest, user: User?): OnDemandReportCreateResponse {
-        return ReportInstanceActions.createOnDemandFromDefinition(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: OnDemandReportCreateRequest,
+            user: User?,
+        ): OnDemandReportCreateResponse = ReportInstanceActions.createOnDemandFromDefinition(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/PluginBaseAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/PluginBaseAction.kt
@@ -36,7 +36,7 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
     transportService: TransportService,
     val client: Client,
     actionFilters: ActionFilters,
-    requestReader: Writeable.Reader<Request>
+    requestReader: Writeable.Reader<Request>,
 ) : HandledTransportAction<Request, Response>(name, transportService, actionFilters, requestReader) {
     companion object {
         private val log by logger(PluginBaseAction::class.java)
@@ -50,7 +50,7 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
     override fun doExecute(
         task: Task?,
         request: Request,
-        listener: ActionListener<Response>
+        listener: ActionListener<Response>,
     ) {
         val userStr: String? =
             client.threadPool().threadContext.getTransient<String>(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT)
@@ -72,8 +72,8 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
                 listener.onFailure(
                     OpenSearchStatusException(
                         "Permissions denied: ${exception.message} - Contact administrator",
-                        RestStatus.FORBIDDEN
-                    )
+                        RestStatus.FORBIDDEN,
+                    ),
                 )
             } catch (exception: VersionConflictEngineException) {
                 Metrics.REPORT_EXCEPTIONS_VERSION_CONFLICT_ENGINE_EXCEPTION.counter.increment()
@@ -112,7 +112,10 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
      * @param request the request to execute
      * @return the response to return.
      */
-    abstract fun executeRequest(request: Request, user: User?): Response
+    abstract fun executeRequest(
+        request: Request,
+        user: User?,
+    ): Response
 
     /**
      * Executes the given [block] function on this resource and then closes it down correctly whether an exception
@@ -144,12 +147,18 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
      * The suppressed exception is added to the list of suppressed exceptions of [cause] exception.
      */
     @Suppress("TooGenericExceptionCaught")
-    private fun ThreadContext.StoredContext.closeFinally(cause: Throwable?) = when (cause) {
-        null -> close()
-        else -> try {
-            close()
-        } catch (closeException: Throwable) {
-            cause.addSuppressed(closeException)
+    private fun ThreadContext.StoredContext.closeFinally(cause: Throwable?) =
+        when (cause) {
+            null -> {
+                close()
+            }
+
+            else -> {
+                try {
+                    close()
+                } catch (closeException: Throwable) {
+                    cause.addSuppressed(closeException)
+                }
+            }
         }
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
@@ -37,22 +37,26 @@ internal object ReportDefinitionActions {
      * @param request [CreateReportDefinitionRequest] object
      * @return [CreateReportDefinitionResponse]
      */
-    fun create(request: CreateReportDefinitionRequest, user: User?): CreateReportDefinitionResponse {
+    fun create(
+        request: CreateReportDefinitionRequest,
+        user: User?,
+    ): CreateReportDefinitionResponse {
         log.info("$LOG_PREFIX:ReportDefinition-create")
         UserAccessManager.validateUser(user)
         val currentTime = Instant.now()
-        val reportDefinitionDetails = ReportDefinitionDetails(
-            "ignore",
-            currentTime,
-            currentTime,
-            UserAccessManager.getUserTenant(user),
-            UserAccessManager.getAllAccessInfo(user),
-            request.reportDefinition
-        )
+        val reportDefinitionDetails =
+            ReportDefinitionDetails(
+                "ignore",
+                currentTime,
+                currentTime,
+                UserAccessManager.getUserTenant(user),
+                UserAccessManager.getAllAccessInfo(user),
+                request.reportDefinition,
+            )
         val docId = ReportDefinitionsIndex.createReportDefinition(reportDefinitionDetails)
         docId ?: throw OpenSearchStatusException(
             "Report Definition Creation failed",
-            RestStatus.INTERNAL_SERVER_ERROR
+            RestStatus.INTERNAL_SERVER_ERROR,
         )
         return CreateReportDefinitionResponse(docId)
     }
@@ -62,7 +66,10 @@ internal object ReportDefinitionActions {
      * @param request [UpdateReportDefinitionRequest] object
      * @return [UpdateReportDefinitionResponse]
      */
-    fun update(request: UpdateReportDefinitionRequest, user: User?): UpdateReportDefinitionResponse {
+    fun update(
+        request: UpdateReportDefinitionRequest,
+        user: User?,
+    ): UpdateReportDefinitionResponse {
         log.info("$LOG_PREFIX:ReportDefinition-update ${request.reportDefinitionId}")
         UserAccessManager.validateUser(user)
         val currentReportDefinitionDetails = ReportDefinitionsIndex.getReportDefinition(request.reportDefinitionId)
@@ -77,14 +84,15 @@ internal object ReportDefinitionActions {
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportDefinitionId}", RestStatus.FORBIDDEN)
         }
         val currentTime = Instant.now()
-        val reportDefinitionDetails = ReportDefinitionDetails(
-            request.reportDefinitionId,
-            currentTime,
-            currentReportDefinitionDetails.createdTime,
-            UserAccessManager.getUserTenant(user),
-            currentReportDefinitionDetails.access,
-            request.reportDefinition
-        )
+        val reportDefinitionDetails =
+            ReportDefinitionDetails(
+                request.reportDefinitionId,
+                currentTime,
+                currentReportDefinitionDetails.createdTime,
+                UserAccessManager.getUserTenant(user),
+                currentReportDefinitionDetails.access,
+                request.reportDefinition,
+            )
         if (!ReportDefinitionsIndex.updateReportDefinition(request.reportDefinitionId, reportDefinitionDetails)) {
             Metrics.REPORT_DEFINITION_UPDATE_SYSTEM_ERROR.counter.increment()
             throw OpenSearchStatusException("Report Definition Update failed", RestStatus.INTERNAL_SERVER_ERROR)
@@ -97,7 +105,10 @@ internal object ReportDefinitionActions {
      * @param request [GetReportDefinitionRequest] object
      * @return [GetReportDefinitionResponse]
      */
-    fun info(request: GetReportDefinitionRequest, user: User?): GetReportDefinitionResponse {
+    fun info(
+        request: GetReportDefinitionRequest,
+        user: User?,
+    ): GetReportDefinitionResponse {
         log.info("$LOG_PREFIX:ReportDefinition-info ${request.reportDefinitionId}")
         UserAccessManager.validateUser(user)
         val reportDefinitionDetails = ReportDefinitionsIndex.getReportDefinition(request.reportDefinitionId)
@@ -119,7 +130,10 @@ internal object ReportDefinitionActions {
      * @param request [DeleteReportDefinitionRequest] object
      * @return [DeleteReportDefinitionResponse]
      */
-    fun delete(request: DeleteReportDefinitionRequest, user: User?): DeleteReportDefinitionResponse {
+    fun delete(
+        request: DeleteReportDefinitionRequest,
+        user: User?,
+    ): DeleteReportDefinitionResponse {
         log.info("$LOG_PREFIX:ReportDefinition-delete ${request.reportDefinitionId}")
         UserAccessManager.validateUser(user)
         val reportDefinitionDetails = ReportDefinitionsIndex.getReportDefinition(request.reportDefinitionId)
@@ -145,15 +159,19 @@ internal object ReportDefinitionActions {
      * @param request [GetAllReportDefinitionsRequest] object
      * @return [GetAllReportDefinitionsResponse]
      */
-    fun getAll(request: GetAllReportDefinitionsRequest, user: User?): GetAllReportDefinitionsResponse {
+    fun getAll(
+        request: GetAllReportDefinitionsRequest,
+        user: User?,
+    ): GetAllReportDefinitionsResponse {
         log.info("$LOG_PREFIX:ReportDefinition-getAll fromIndex:${request.fromIndex} maxItems:${request.maxItems}")
         UserAccessManager.validateUser(user)
-        val reportDefinitionsList = ReportDefinitionsIndex.getAllReportDefinitions(
-            UserAccessManager.getUserTenant(user),
-            UserAccessManager.getSearchAccessInfo(user),
-            request.fromIndex,
-            request.maxItems
-        )
+        val reportDefinitionsList =
+            ReportDefinitionsIndex.getAllReportDefinitions(
+                UserAccessManager.getUserTenant(user),
+                UserAccessManager.getSearchAccessInfo(user),
+                request.fromIndex,
+                request.maxItems,
+            )
         return GetAllReportDefinitionsResponse(reportDefinitionsList, true)
     }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportDefinitionAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportDefinitionAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Update reportDefinitions transport action
  */
-internal class UpdateReportDefinitionAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<UpdateReportDefinitionRequest, UpdateReportDefinitionResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::UpdateReportDefinitionRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/update"
-        internal val ACTION_TYPE = ActionType(NAME, ::UpdateReportDefinitionResponse)
-    }
+internal class UpdateReportDefinitionAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<UpdateReportDefinitionRequest, UpdateReportDefinitionResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::UpdateReportDefinitionRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/definition/update"
+            internal val ACTION_TYPE = ActionType(NAME, ::UpdateReportDefinitionResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: UpdateReportDefinitionRequest, user: User?): UpdateReportDefinitionResponse {
-        return ReportDefinitionActions.update(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: UpdateReportDefinitionRequest,
+            user: User?,
+        ): UpdateReportDefinitionResponse = ReportDefinitionActions.update(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportInstanceStatusAction.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/UpdateReportInstanceStatusAction.kt
@@ -18,27 +18,30 @@ import org.opensearch.transport.client.Client
 /**
  * Update ReportInstance Status transport action
  */
-internal class UpdateReportInstanceStatusAction @Inject constructor(
-    transportService: TransportService,
-    client: Client,
-    actionFilters: ActionFilters,
-    val xContentRegistry: NamedXContentRegistry
-) : PluginBaseAction<UpdateReportInstanceStatusRequest, UpdateReportInstanceStatusResponse>(
-    NAME,
-    transportService,
-    client,
-    actionFilters,
-    ::UpdateReportInstanceStatusRequest
-) {
-    companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/instance/update_status"
-        internal val ACTION_TYPE = ActionType(NAME, ::UpdateReportInstanceStatusResponse)
-    }
+internal class UpdateReportInstanceStatusAction
+    @Inject
+    constructor(
+        transportService: TransportService,
+        client: Client,
+        actionFilters: ActionFilters,
+        val xContentRegistry: NamedXContentRegistry,
+    ) : PluginBaseAction<UpdateReportInstanceStatusRequest, UpdateReportInstanceStatusResponse>(
+            NAME,
+            transportService,
+            client,
+            actionFilters,
+            ::UpdateReportInstanceStatusRequest,
+        ) {
+        companion object {
+            private const val NAME = "cluster:admin/opendistro/reports/instance/update_status"
+            internal val ACTION_TYPE = ActionType(NAME, ::UpdateReportInstanceStatusResponse)
+        }
 
-    /**
-     * {@inheritDoc}
-     */
-    override fun executeRequest(request: UpdateReportInstanceStatusRequest, user: User?): UpdateReportInstanceStatusResponse {
-        return ReportInstanceActions.update(request, user)
+        /**
+         * {@inheritDoc}
+         */
+        override fun executeRequest(
+            request: UpdateReportInstanceStatusRequest,
+            user: User?,
+        ): UpdateReportInstanceStatusResponse = ReportInstanceActions.update(request, user)
     }
-}

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/BaseResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/BaseResponse.kt
@@ -15,20 +15,17 @@ import org.opensearch.core.xcontent.XContentBuilder
 /**
  * Base response which give REST status.
  */
-internal abstract class BaseResponse : ActionResponse(), ToXContentObject {
-
+internal abstract class BaseResponse :
+    ActionResponse(),
+    ToXContentObject {
     /**
      * {@inheritDoc}
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * get rest status for the response. Useful override for multi-status response.
      * @return RestStatus for the response
      */
-    open fun getStatus(): RestStatus {
-        return RestStatus.OK
-    }
+    open fun getStatus(): RestStatus = RestStatus.OK
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionRequest.kt
@@ -34,7 +34,9 @@ import java.io.IOException
  * }
  * }</pre>
  */
-internal class CreateReportDefinitionRequest : ActionRequest, ToXContentObject {
+internal class CreateReportDefinitionRequest :
+    ActionRequest,
+    ToXContentObject {
     val reportDefinition: ReportDefinition
 
     companion object {
@@ -59,7 +61,10 @@ internal class CreateReportDefinitionRequest : ActionRequest, ToXContentObject {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                REPORT_DEFINITION_FIELD -> reportDefinition = ReportDefinition.parse(parser)
+                REPORT_DEFINITION_FIELD -> {
+                    reportDefinition = ReportDefinition.parse(parser)
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -86,23 +91,22 @@ internal class CreateReportDefinitionRequest : ActionRequest, ToXContentObject {
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_FIELD, reportDefinition)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionResponse.kt
@@ -28,12 +28,11 @@ import java.io.IOException
  * }</pre>
  */
 internal class CreateReportDefinitionResponse(
-    val reportDefinitionId: String
+    val reportDefinitionId: String,
 ) : BaseResponse() {
-
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportDefinitionId = input.readString()
+        reportDefinitionId = input.readString(),
     )
 
     companion object {
@@ -51,7 +50,10 @@ internal class CreateReportDefinitionResponse(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
+                    REPORT_DEFINITION_ID_FIELD -> {
+                        reportDefinitionId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -77,9 +79,12 @@ internal class CreateReportDefinitionResponse(
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .endObject()
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionRequest.kt
@@ -33,12 +33,12 @@ import java.io.IOException
  * }</pre>
  */
 internal class DeleteReportDefinitionRequest(
-    val reportDefinitionId: String
-) : ActionRequest(), ToXContentObject {
-
+    val reportDefinitionId: String,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportDefinitionId = input.readString()
+        reportDefinitionId = input.readString(),
     )
 
     companion object {
@@ -50,14 +50,20 @@ internal class DeleteReportDefinitionRequest(
          * @param useReportDefinitionId use this id if not available in the json
          * @return created [DeleteReportDefinitionRequest] object
          */
-        fun parse(parser: XContentParser, useReportDefinitionId: String? = null): DeleteReportDefinitionRequest {
+        fun parse(
+            parser: XContentParser,
+            useReportDefinitionId: String? = null,
+        ): DeleteReportDefinitionRequest {
             var reportDefinitionId: String? = useReportDefinitionId
             XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser)
             while (Token.END_OBJECT != parser.nextToken()) {
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
+                    REPORT_DEFINITION_ID_FIELD -> {
+                        reportDefinitionId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -85,23 +91,22 @@ internal class DeleteReportDefinitionRequest(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionResponse.kt
@@ -28,12 +28,11 @@ import java.io.IOException
  * }</pre>
  */
 internal data class DeleteReportDefinitionResponse(
-    val reportDefinitionId: String
+    val reportDefinitionId: String,
 ) : BaseResponse() {
-
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportDefinitionId = input.readString()
+        reportDefinitionId = input.readString(),
     )
 
     companion object {
@@ -51,7 +50,10 @@ internal data class DeleteReportDefinitionResponse(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
+                    REPORT_DEFINITION_ID_FIELD -> {
+                        reportDefinitionId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -77,9 +79,12 @@ internal data class DeleteReportDefinitionResponse(
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .endObject()
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsRequest.kt
@@ -37,13 +37,13 @@ import java.io.IOException
  */
 internal class GetAllReportDefinitionsRequest(
     val fromIndex: Int,
-    val maxItems: Int
-) : ActionRequest(), ToXContentObject {
-
+    val maxItems: Int,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
         fromIndex = input.readInt(),
-        maxItems = input.readInt()
+        maxItems = input.readInt(),
     )
 
     companion object {
@@ -62,8 +62,14 @@ internal class GetAllReportDefinitionsRequest(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    FROM_INDEX_FIELD -> fromIndex = parser.intValue()
-                    MAX_ITEMS_FIELD -> maxItems = parser.intValue()
+                    FROM_INDEX_FIELD -> {
+                        fromIndex = parser.intValue()
+                    }
+
+                    MAX_ITEMS_FIELD -> {
+                        maxItems = parser.intValue()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -86,8 +92,8 @@ internal class GetAllReportDefinitionsRequest(
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return if (fromIndex < 0) {
+    override fun validate(): ActionRequestValidationException? =
+        if (fromIndex < 0) {
             val exception = ActionRequestValidationException()
             exception.addValidationError("fromIndex should be greater than 0")
             Metrics.REPORT_DEFINITION_LIST_USER_ERROR_INVALID_FROM_INDEX.counter.increment()
@@ -95,24 +101,24 @@ internal class GetAllReportDefinitionsRequest(
         } else {
             null
         }
-    }
 
     /**
      * create XContentBuilder from this object using [XContentFactory.jsonBuilder()]
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(FROM_INDEX_FIELD, fromIndex)
             .field(MAX_ITEMS_FIELD, maxItems)
             .endObject()
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsResponse.kt
@@ -60,12 +60,16 @@ internal class GetAllReportDefinitionsResponse : BaseResponse {
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        val xContentParams = if (filterSensitiveInfo) {
-            RestTag.FILTERED_REST_OUTPUT_PARAMS
-        } else {
-            RestTag.REST_OUTPUT_PARAMS
-        }
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        val xContentParams =
+            if (filterSensitiveInfo) {
+                RestTag.FILTERED_REST_OUTPUT_PARAMS
+            } else {
+                RestTag.REST_OUTPUT_PARAMS
+            }
         return reportDefinitionList.toXContent(builder, xContentParams)
     }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesRequest.kt
@@ -37,13 +37,13 @@ import java.io.IOException
  */
 internal data class GetAllReportInstancesRequest(
     val fromIndex: Int,
-    val maxItems: Int
-) : ActionRequest(), ToXContentObject {
-
+    val maxItems: Int,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
         fromIndex = input.readInt(),
-        maxItems = input.readInt()
+        maxItems = input.readInt(),
     )
 
     companion object {
@@ -62,8 +62,14 @@ internal data class GetAllReportInstancesRequest(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    FROM_INDEX_FIELD -> fromIndex = parser.intValue()
-                    MAX_ITEMS_FIELD -> maxItems = parser.intValue()
+                    FROM_INDEX_FIELD -> {
+                        fromIndex = parser.intValue()
+                    }
+
+                    MAX_ITEMS_FIELD -> {
+                        maxItems = parser.intValue()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -86,8 +92,8 @@ internal data class GetAllReportInstancesRequest(
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return if (fromIndex < 0) {
+    override fun validate(): ActionRequestValidationException? =
+        if (fromIndex < 0) {
             val exception = ActionRequestValidationException()
             exception.addValidationError("fromIndex should be greater than 0")
             Metrics.REPORT_INSTANCE_LIST_USER_ERROR_INVALID_FROM_INDEX.counter.increment()
@@ -95,24 +101,24 @@ internal data class GetAllReportInstancesRequest(
         } else {
             null
         }
-    }
 
     /**
      * create XContentBuilder from this object using [XContentFactory.jsonBuilder()]
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(FROM_INDEX_FIELD, fromIndex)
             .field(MAX_ITEMS_FIELD, maxItems)
             .endObject()
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesResponse.kt
@@ -60,12 +60,16 @@ internal class GetAllReportInstancesResponse : BaseResponse {
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        val xContentParams = if (filterSensitiveInfo) {
-            RestTag.FILTERED_REST_OUTPUT_PARAMS
-        } else {
-            RestTag.REST_OUTPUT_PARAMS
-        }
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        val xContentParams =
+            if (filterSensitiveInfo) {
+                RestTag.FILTERED_REST_OUTPUT_PARAMS
+            } else {
+                RestTag.REST_OUTPUT_PARAMS
+            }
         return reportInstanceList.toXContent(builder, xContentParams)
     }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionRequest.kt
@@ -33,12 +33,12 @@ import java.io.IOException
  * }</pre>
  */
 internal class GetReportDefinitionRequest(
-    val reportDefinitionId: String
-) : ActionRequest(), ToXContentObject {
-
+    val reportDefinitionId: String,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportDefinitionId = input.readString()
+        reportDefinitionId = input.readString(),
     )
 
     companion object {
@@ -50,14 +50,20 @@ internal class GetReportDefinitionRequest(
          * @param useReportDefinitionId use this id if not available in the json
          * @return created [GetReportDefinitionRequest] object
          */
-        fun parse(parser: XContentParser, useReportDefinitionId: String? = null): GetReportDefinitionRequest {
+        fun parse(
+            parser: XContentParser,
+            useReportDefinitionId: String? = null,
+        ): GetReportDefinitionRequest {
             var reportDefinitionId: String? = useReportDefinitionId
             XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser)
             while (Token.END_OBJECT != parser.nextToken()) {
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
+                    REPORT_DEFINITION_ID_FIELD -> {
+                        reportDefinitionId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -85,23 +91,22 @@ internal class GetReportDefinitionRequest(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionResponse.kt
@@ -57,7 +57,10 @@ internal class GetReportDefinitionResponse : BaseResponse {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                RestTag.REPORT_DEFINITION_DETAILS_FIELD -> reportDefinition = ReportDefinitionDetails.parse(parser)
+                RestTag.REPORT_DEFINITION_DETAILS_FIELD -> {
+                    reportDefinition = ReportDefinitionDetails.parse(parser)
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -83,13 +86,18 @@ internal class GetReportDefinitionResponse : BaseResponse {
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        val xContentParams = if (filterSensitiveInfo) {
-            RestTag.FILTERED_REST_OUTPUT_PARAMS
-        } else {
-            RestTag.REST_OUTPUT_PARAMS
-        }
-        builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        val xContentParams =
+            if (filterSensitiveInfo) {
+                RestTag.FILTERED_REST_OUTPUT_PARAMS
+            } else {
+                RestTag.REST_OUTPUT_PARAMS
+            }
+        builder!!
+            .startObject()
             .field(RestTag.REPORT_DEFINITION_DETAILS_FIELD)
         reportDefinitionDetails.toXContent(builder, xContentParams)
         return builder.endObject()

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceRequest.kt
@@ -33,12 +33,12 @@ import java.io.IOException
  * }</pre>
  */
 internal class GetReportInstanceRequest(
-    val reportInstanceId: String
-) : ActionRequest(), ToXContentObject {
-
+    val reportInstanceId: String,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportInstanceId = input.readString()
+        reportInstanceId = input.readString(),
     )
 
     companion object {
@@ -49,14 +49,20 @@ internal class GetReportInstanceRequest(
          * @param parser data referenced at parser
          * @return created [GetReportInstanceRequest] object
          */
-        fun parse(parser: XContentParser, useReportInstanceId: String? = null): GetReportInstanceRequest {
+        fun parse(
+            parser: XContentParser,
+            useReportInstanceId: String? = null,
+        ): GetReportInstanceRequest {
             var reportInstanceId: String? = useReportInstanceId
             XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser)
             while (Token.END_OBJECT != parser.nextToken()) {
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_INSTANCE_ID_FIELD -> reportInstanceId = parser.text()
+                    REPORT_INSTANCE_ID_FIELD -> {
+                        reportInstanceId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -85,23 +91,22 @@ internal class GetReportInstanceRequest(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_INSTANCE_ID_FIELD, reportInstanceId)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceResponse.kt
@@ -57,7 +57,10 @@ internal class GetReportInstanceResponse : BaseResponse {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                REPORT_INSTANCE_FIELD -> reportInstance = ReportInstance.parse(parser)
+                REPORT_INSTANCE_FIELD -> {
+                    reportInstance = ReportInstance.parse(parser)
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -80,13 +83,18 @@ internal class GetReportInstanceResponse : BaseResponse {
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        val xContentParams = if (filterSensitiveInfo) {
-            RestTag.FILTERED_REST_OUTPUT_PARAMS
-        } else {
-            RestTag.REST_OUTPUT_PARAMS
-        }
-        builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        val xContentParams =
+            if (filterSensitiveInfo) {
+                RestTag.FILTERED_REST_OUTPUT_PARAMS
+            } else {
+                RestTag.REST_OUTPUT_PARAMS
+            }
+        builder!!
+            .startObject()
             .field(REPORT_INSTANCE_FIELD)
         reportInstance.toXContent(builder, xContentParams)
         return builder.endObject()

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateRequest.kt
@@ -48,7 +48,9 @@ import java.time.Instant
  * }
  * }</pre>
  */
-internal class InContextReportCreateRequest : ActionRequest, ToXContentObject {
+internal class InContextReportCreateRequest :
+    ActionRequest,
+    ToXContentObject {
     val beginTime: Instant
     val endTime: Instant
     val reportDefinitionDetails: ReportDefinitionDetails?
@@ -66,7 +68,7 @@ internal class InContextReportCreateRequest : ActionRequest, ToXContentObject {
         reportDefinitionDetails: ReportDefinitionDetails?,
         status: Status,
         statusText: String? = null,
-        inContextDownloadUrlPath: String? = null
+        inContextDownloadUrlPath: String? = null,
     ) : super() {
         this.beginTime = beginTime
         this.endTime = endTime
@@ -95,12 +97,30 @@ internal class InContextReportCreateRequest : ActionRequest, ToXContentObject {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                BEGIN_TIME_FIELD -> beginTime = Instant.ofEpochMilli(parser.longValue())
-                END_TIME_FIELD -> endTime = Instant.ofEpochMilli(parser.longValue())
-                REPORT_DEFINITION_DETAILS_FIELD -> reportDefinitionDetails = ReportDefinitionDetails.parse(parser)
-                STATUS_FIELD -> status = Status.valueOf(parser.text())
-                STATUS_TEXT_FIELD -> statusText = parser.text()
-                IN_CONTEXT_DOWNLOAD_URL_FIELD -> inContextDownloadUrlPath = parser.text()
+                BEGIN_TIME_FIELD -> {
+                    beginTime = Instant.ofEpochMilli(parser.longValue())
+                }
+
+                END_TIME_FIELD -> {
+                    endTime = Instant.ofEpochMilli(parser.longValue())
+                }
+
+                REPORT_DEFINITION_DETAILS_FIELD -> {
+                    reportDefinitionDetails = ReportDefinitionDetails.parse(parser)
+                }
+
+                STATUS_FIELD -> {
+                    status = Status.valueOf(parser.text())
+                }
+
+                STATUS_TEXT_FIELD -> {
+                    statusText = parser.text()
+                }
+
+                IN_CONTEXT_DOWNLOAD_URL_FIELD -> {
+                    inContextDownloadUrlPath = parser.text()
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:InContextReportCreateRequest Skipping Unknown field $fieldName")
@@ -140,22 +160,25 @@ internal class InContextReportCreateRequest : ActionRequest, ToXContentObject {
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        builder!!
+            .startObject()
             .field(BEGIN_TIME_FIELD, beginTime.toEpochMilli())
             .field(END_TIME_FIELD, endTime.toEpochMilli())
         if (reportDefinitionDetails != null) {
             builder.field(REPORT_DEFINITION_DETAILS_FIELD)
             reportDefinitionDetails.toXContent(builder, REST_OUTPUT_PARAMS)
         }
-        return builder.field(STATUS_FIELD, status.name)
+        return builder
+            .field(STATUS_FIELD, status.name)
             .fieldIfNotNull(STATUS_TEXT_FIELD, statusText)
             .fieldIfNotNull(IN_CONTEXT_DOWNLOAD_URL_FIELD, inContextDownloadUrlPath)
             .endObject()
@@ -164,7 +187,5 @@ internal class InContextReportCreateRequest : ActionRequest, ToXContentObject {
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateResponse.kt
@@ -57,7 +57,10 @@ internal class InContextReportCreateResponse : BaseResponse {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                REPORT_INSTANCE_FIELD -> reportInstance = ReportInstance.parse(parser)
+                REPORT_INSTANCE_FIELD -> {
+                    reportInstance = ReportInstance.parse(parser)
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -80,13 +83,18 @@ internal class InContextReportCreateResponse : BaseResponse {
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        val xContentParams = if (filterSensitiveInfo) {
-            RestTag.FILTERED_REST_OUTPUT_PARAMS
-        } else {
-            RestTag.REST_OUTPUT_PARAMS
-        }
-        builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        val xContentParams =
+            if (filterSensitiveInfo) {
+                RestTag.FILTERED_REST_OUTPUT_PARAMS
+            } else {
+                RestTag.REST_OUTPUT_PARAMS
+            }
+        builder!!
+            .startObject()
             .field(REPORT_INSTANCE_FIELD)
         reportInstance.toXContent(builder, xContentParams)
         return builder.endObject()

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateRequest.kt
@@ -33,12 +33,12 @@ import java.io.IOException
  * }</pre>
  */
 internal class OnDemandReportCreateRequest(
-    val reportDefinitionId: String
-) : ActionRequest(), ToXContentObject {
-
+    val reportDefinitionId: String,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportDefinitionId = input.readString()
+        reportDefinitionId = input.readString(),
     )
 
     companion object {
@@ -50,14 +50,20 @@ internal class OnDemandReportCreateRequest(
          * @param useReportDefinitionId use this id if not available in the json
          * @return created [OnDemandReportCreateRequest] object
          */
-        fun parse(parser: XContentParser, useReportDefinitionId: String? = null): OnDemandReportCreateRequest {
+        fun parse(
+            parser: XContentParser,
+            useReportDefinitionId: String? = null,
+        ): OnDemandReportCreateRequest {
             var reportDefinitionId: String? = useReportDefinitionId
             XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser)
             while (Token.END_OBJECT != parser.nextToken()) {
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
+                    REPORT_DEFINITION_ID_FIELD -> {
+                        reportDefinitionId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -86,23 +92,22 @@ internal class OnDemandReportCreateRequest(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateResponse.kt
@@ -57,7 +57,10 @@ internal class OnDemandReportCreateResponse : BaseResponse {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                REPORT_INSTANCE_FIELD -> reportInstance = ReportInstance.parse(parser)
+                REPORT_INSTANCE_FIELD -> {
+                    reportInstance = ReportInstance.parse(parser)
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -80,13 +83,18 @@ internal class OnDemandReportCreateResponse : BaseResponse {
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        val xContentParams = if (filterSensitiveInfo) {
-            RestTag.FILTERED_REST_OUTPUT_PARAMS
-        } else {
-            RestTag.REST_OUTPUT_PARAMS
-        }
-        builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
+        val xContentParams =
+            if (filterSensitiveInfo) {
+                RestTag.FILTERED_REST_OUTPUT_PARAMS
+            } else {
+                RestTag.REST_OUTPUT_PARAMS
+            }
+        builder!!
+            .startObject()
             .field(REPORT_INSTANCE_FIELD)
         reportInstance.toXContent(builder, xContentParams)
         return builder.endObject()

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinition.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinition.kt
@@ -70,12 +70,14 @@ internal data class ReportDefinition(
     val source: Source,
     val format: Format,
     val trigger: Trigger,
-    val delivery: Delivery?
+    val delivery: Delivery?,
 ) : ToXContentObject {
-
     internal enum class SourceType { Dashboard, Visualization, SavedSearch, Notebook }
+
     internal enum class TriggerType { Download, OnDemand, CronSchedule, IntervalSchedule }
+
     internal enum class DeliveryFormat { LinkOnly, Attachment, Embedded }
+
     internal enum class FileFormat { Pdf, Png, Csv, Xlsx }
 
     internal companion object {
@@ -104,12 +106,30 @@ internal data class ReportDefinition(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    NAME_TAG -> name = parser.text()
-                    IS_ENABLED_TAG -> isEnabled = parser.booleanValue()
-                    SOURCE_TAG -> source = Source.parse(parser)
-                    FORMAT_TAG -> format = Format.parse(parser)
-                    TRIGGER_TAG -> trigger = Trigger.parse(parser)
-                    DELIVERY_TAG -> delivery = Delivery.parse(parser)
+                    NAME_TAG -> {
+                        name = parser.text()
+                    }
+
+                    IS_ENABLED_TAG -> {
+                        isEnabled = parser.booleanValue()
+                    }
+
+                    SOURCE_TAG -> {
+                        source = Source.parse(parser)
+                    }
+
+                    FORMAT_TAG -> {
+                        format = Format.parse(parser)
+                    }
+
+                    TRIGGER_TAG -> {
+                        trigger = Trigger.parse(parser)
+                    }
+
+                    DELIVERY_TAG -> {
+                        delivery = Delivery.parse(parser)
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:ReportDefinition Skipping Unknown field $fieldName")
@@ -126,7 +146,7 @@ internal data class ReportDefinition(
                 source,
                 format,
                 trigger,
-                delivery
+                delivery,
             )
         }
     }
@@ -136,16 +156,18 @@ internal data class ReportDefinition(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
         builder!!
-        builder.startObject()
+        builder
+            .startObject()
             .field(NAME_TAG, name)
             .field(IS_ENABLED_TAG, isEnabled)
         builder.field(SOURCE_TAG)
@@ -169,7 +191,7 @@ internal data class ReportDefinition(
         val description: String,
         val type: SourceType,
         val origin: String,
-        val id: String
+        val id: String,
     ) : ToXContentObject {
         internal companion object {
             private const val DESCRIPTION_TAG = "description"
@@ -192,10 +214,22 @@ internal data class ReportDefinition(
                     val fieldName = parser.currentName()
                     parser.nextToken()
                     when (fieldName) {
-                        DESCRIPTION_TAG -> description = parser.text()
-                        TYPE_TAG -> type = SourceType.valueOf(parser.text())
-                        ORIGIN_TAG -> origin = parser.text()
-                        ID_TAG -> id = parser.text()
+                        DESCRIPTION_TAG -> {
+                            description = parser.text()
+                        }
+
+                        TYPE_TAG -> {
+                            type = SourceType.valueOf(parser.text())
+                        }
+
+                        ORIGIN_TAG -> {
+                            origin = parser.text()
+                        }
+
+                        ID_TAG -> {
+                            id = parser.text()
+                        }
+
                         else -> {
                             parser.skipChildren()
                             log.info("$LOG_PREFIX:Source Skipping Unknown field $fieldName")
@@ -210,7 +244,7 @@ internal data class ReportDefinition(
                     description,
                     type,
                     origin,
-                    id
+                    id,
                 )
             }
         }
@@ -218,9 +252,13 @@ internal data class ReportDefinition(
         /**
          * {@inheritDoc}
          */
-        override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+        override fun toXContent(
+            builder: XContentBuilder?,
+            params: ToXContent.Params?,
+        ): XContentBuilder {
             builder!!
-            builder.startObject()
+            builder
+                .startObject()
                 .field(DESCRIPTION_TAG, description)
                 .field(TYPE_TAG, type.name)
                 .field(ORIGIN_TAG, origin)
@@ -240,7 +278,7 @@ internal data class ReportDefinition(
         val header: String?,
         val footer: String?,
         val timeFrom: String?,
-        val timeTo: String?
+        val timeTo: String?,
     ) : ToXContentObject {
         internal companion object {
             private const val DURATION_TAG = "duration"
@@ -269,13 +307,34 @@ internal data class ReportDefinition(
                     val fieldName = parser.currentName()
                     parser.nextToken()
                     when (fieldName) {
-                        DURATION_TAG -> durationSeconds = Duration.parse(parser.text())
-                        FILE_FORMAT_TAG -> fileFormat = FileFormat.valueOf(parser.text())
-                        LIMIT_TAG -> limit = parser.intValue()
-                        HEADER_TAG -> header = parser.textOrNull()
-                        FOOTER_TAG -> footer = parser.textOrNull()
-                        TIME_FROM_TAG -> timeFrom = parser.textOrNull()
-                        TIME_TO_TAG -> timeTo = parser.textOrNull()
+                        DURATION_TAG -> {
+                            durationSeconds = Duration.parse(parser.text())
+                        }
+
+                        FILE_FORMAT_TAG -> {
+                            fileFormat = FileFormat.valueOf(parser.text())
+                        }
+
+                        LIMIT_TAG -> {
+                            limit = parser.intValue()
+                        }
+
+                        HEADER_TAG -> {
+                            header = parser.textOrNull()
+                        }
+
+                        FOOTER_TAG -> {
+                            footer = parser.textOrNull()
+                        }
+
+                        TIME_FROM_TAG -> {
+                            timeFrom = parser.textOrNull()
+                        }
+
+                        TIME_TO_TAG -> {
+                            timeTo = parser.textOrNull()
+                        }
+
                         else -> {
                             parser.skipChildren()
                             log.info("$LOG_PREFIX:Format Skipping Unknown field $fieldName")
@@ -291,7 +350,7 @@ internal data class ReportDefinition(
                     header,
                     footer,
                     timeFrom,
-                    timeTo
+                    timeTo,
                 )
             }
         }
@@ -299,9 +358,13 @@ internal data class ReportDefinition(
         /**
          * {@inheritDoc}
          */
-        override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+        override fun toXContent(
+            builder: XContentBuilder?,
+            params: ToXContent.Params?,
+        ): XContentBuilder {
             builder!!
-            builder.startObject()
+            builder
+                .startObject()
                 .field(DURATION_TAG, duration.toString())
                 .field(FILE_FORMAT_TAG, fileFormat.name)
             if (limit != null) builder.field(LIMIT_TAG, limit)
@@ -319,7 +382,7 @@ internal data class ReportDefinition(
      */
     internal data class Trigger(
         val triggerType: TriggerType,
-        val schedule: Schedule?
+        val schedule: Schedule?,
     ) : ToXContentObject {
         internal companion object {
             private const val TRIGGER_TYPE_TAG = "triggerType"
@@ -350,17 +413,19 @@ internal data class ReportDefinition(
                 return Trigger(triggerType, schedule)
             }
 
-            fun isScheduleType(triggerType: TriggerType): Boolean {
-                return (triggerType == TriggerType.CronSchedule || triggerType == TriggerType.IntervalSchedule)
-            }
+            fun isScheduleType(triggerType: TriggerType): Boolean = (triggerType == TriggerType.CronSchedule || triggerType == TriggerType.IntervalSchedule)
         }
 
         /**
          * {@inheritDoc}
          */
-        override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+        override fun toXContent(
+            builder: XContentBuilder?,
+            params: ToXContent.Params?,
+        ): XContentBuilder {
             builder!!
-            builder.startObject()
+            builder
+                .startObject()
                 .field(TRIGGER_TYPE_TAG, triggerType)
             if (isScheduleType(triggerType)) {
                 builder.field(SCHEDULE_TAG)
@@ -378,7 +443,7 @@ internal data class ReportDefinition(
         val title: String,
         val textDescription: String,
         val htmlDescription: String?,
-        val configIds: List<String>
+        val configIds: List<String>,
     ) : ToXContentObject {
         internal companion object {
             private const val TITLE_TAG = "title"
@@ -414,7 +479,7 @@ internal data class ReportDefinition(
                     title,
                     textDescription,
                     htmlDescription,
-                    configIds
+                    configIds,
                 )
             }
         }
@@ -422,9 +487,13 @@ internal data class ReportDefinition(
         /**
          * {@inheritDoc}
          */
-        override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+        override fun toXContent(
+            builder: XContentBuilder?,
+            params: ToXContent.Params?,
+        ): XContentBuilder {
             builder!!
-            builder.startObject()
+            builder
+                .startObject()
                 .field(TITLE_TAG, title)
                 .field(TEXT_DESCRIPTION_TAG, textDescription)
             if (htmlDescription != null) {

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinitionDetails.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinitionDetails.kt
@@ -48,7 +48,7 @@ internal data class ReportDefinitionDetails(
     val createdTime: Instant,
     val tenant: String,
     val access: List<String>,
-    val reportDefinition: ReportDefinition
+    val reportDefinition: ReportDefinition,
 ) : ScheduledJobParameter {
     internal companion object {
         private val log by logger(ReportDefinitionDetails::class.java)
@@ -59,7 +59,10 @@ internal data class ReportDefinitionDetails(
          * @param useId use this id if not available in the json
          * @return created ReportDefinitionDetails object
          */
-        fun parse(parser: XContentParser, useId: String? = null): ReportDefinitionDetails {
+        fun parse(
+            parser: XContentParser,
+            useId: String? = null,
+        ): ReportDefinitionDetails {
             var id: String? = useId
             var updatedTime: Instant? = null
             var createdTime: Instant? = null
@@ -71,12 +74,30 @@ internal data class ReportDefinitionDetails(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    ID_FIELD -> id = parser.text()
-                    UPDATED_TIME_FIELD -> updatedTime = Instant.ofEpochMilli(parser.longValue())
-                    CREATED_TIME_FIELD -> createdTime = Instant.ofEpochMilli(parser.longValue())
-                    TENANT_FIELD -> tenant = parser.text()
-                    ACCESS_LIST_FIELD -> access = parser.stringList()
-                    REPORT_DEFINITION_FIELD -> reportDefinition = ReportDefinition.parse(parser)
+                    ID_FIELD -> {
+                        id = parser.text()
+                    }
+
+                    UPDATED_TIME_FIELD -> {
+                        updatedTime = Instant.ofEpochMilli(parser.longValue())
+                    }
+
+                    CREATED_TIME_FIELD -> {
+                        createdTime = Instant.ofEpochMilli(parser.longValue())
+                    }
+
+                    TENANT_FIELD -> {
+                        tenant = parser.text()
+                    }
+
+                    ACCESS_LIST_FIELD -> {
+                        access = parser.stringList()
+                    }
+
+                    REPORT_DEFINITION_FIELD -> {
+                        reportDefinition = ReportDefinition.parse(parser)
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:ReportDefinitionDetails Skipping Unknown field $fieldName")
@@ -94,7 +115,7 @@ internal data class ReportDefinitionDetails(
                 createdTime,
                 tenant,
                 access,
-                reportDefinition
+                reportDefinition,
             )
         }
     }
@@ -104,20 +125,22 @@ internal data class ReportDefinitionDetails(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {ref toXContent}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
         builder!!
         builder.startObject()
         if (params?.paramAsBoolean(ID_FIELD, false) == true) {
             builder.field(ID_FIELD, id)
         }
-        builder.field(UPDATED_TIME_FIELD, updatedTime.toEpochMilli())
+        builder
+            .field(UPDATED_TIME_FIELD, updatedTime.toEpochMilli())
             .field(CREATED_TIME_FIELD, createdTime.toEpochMilli())
             .field(TENANT_FIELD, tenant)
         if (params?.paramAsBoolean(ACCESS_LIST_FIELD, true) == true && access.isNotEmpty()) {
@@ -132,27 +155,19 @@ internal data class ReportDefinitionDetails(
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return reportDefinition.name
-    }
+    override fun getName(): String = reportDefinition.name
 
     /**
      * {@inheritDoc}
      */
-    override fun getLastUpdateTime(): Instant {
-        return updatedTime
-    }
+    override fun getLastUpdateTime(): Instant = updatedTime
 
     /**
      * {@inheritDoc}
      */
-    override fun getEnabledTime(): Instant {
-        return createdTime
-    }
+    override fun getEnabledTime(): Instant = createdTime
 
-    override fun getSchedule(): Schedule {
-        return reportDefinition.trigger.schedule!!
-    }
+    override fun getSchedule(): Schedule = reportDefinition.trigger.schedule!!
 
     override fun isEnabled(): Boolean {
         val trigger = reportDefinition.trigger
@@ -160,6 +175,6 @@ internal data class ReportDefinitionDetails(
             reportDefinition.isEnabled &&
                 (reportDefinition.trigger.schedule != null) &&
                 (trigger.triggerType == TriggerType.IntervalSchedule || trigger.triggerType == TriggerType.CronSchedule)
-            )
+        )
     }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinitionDetailsDoc.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinitionDetailsDoc.kt
@@ -10,5 +10,5 @@ import org.opensearch.index.seqno.SequenceNumbers
 internal data class ReportDefinitionDetailsDoc(
     val reportDefinitionDetails: ReportDefinitionDetails,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
-    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
 )

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinitionDetailsSearchResults.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportDefinitionDetailsSearchResults.kt
@@ -18,7 +18,7 @@ internal class ReportDefinitionDetailsSearchResults : SearchResults<ReportDefini
         startIndex: Long,
         totalHits: Long,
         totalHitRelation: TotalHits.Relation,
-        objectList: List<ReportDefinitionDetails>
+        objectList: List<ReportDefinitionDetails>,
     ) : super(startIndex, totalHits, totalHitRelation, objectList, REPORT_DEFINITION_LIST_FIELD)
 
     constructor(parser: XContentParser) : super(parser, REPORT_DEFINITION_LIST_FIELD)
@@ -28,7 +28,8 @@ internal class ReportDefinitionDetailsSearchResults : SearchResults<ReportDefini
     /**
      * {@inheritDoc}
      */
-    override fun parseItem(parser: XContentParser, useId: String?): ReportDefinitionDetails {
-        return ReportDefinitionDetails.parse(parser, useId)
-    }
+    override fun parseItem(
+        parser: XContentParser,
+        useId: String?,
+    ): ReportDefinitionDetails = ReportDefinitionDetails.parse(parser, useId)
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportInstance.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportInstance.kt
@@ -61,9 +61,10 @@ internal data class ReportInstance(
     val reportDefinitionDetails: ReportDefinitionDetails?,
     val status: Status,
     val statusText: String? = null,
-    val inContextDownloadUrlPath: String? = null
+    val inContextDownloadUrlPath: String? = null,
 ) : ToXContentObject {
     internal enum class Status { Scheduled, Executing, Success, Failed }
+
     companion object {
         private val log by logger(ReportInstance::class.java)
 
@@ -73,7 +74,10 @@ internal data class ReportInstance(
          * @return created ReportInstance object
          */
         @Suppress("ComplexMethod")
-        fun parse(parser: XContentParser, useId: String? = null): ReportInstance {
+        fun parse(
+            parser: XContentParser,
+            useId: String? = null,
+        ): ReportInstance {
             var id: String? = useId
             var updatedTime: Instant? = null
             var createdTime: Instant? = null
@@ -90,17 +94,50 @@ internal data class ReportInstance(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    ID_FIELD -> id = parser.text()
-                    UPDATED_TIME_FIELD -> updatedTime = Instant.ofEpochMilli(parser.longValue())
-                    CREATED_TIME_FIELD -> createdTime = Instant.ofEpochMilli(parser.longValue())
-                    BEGIN_TIME_FIELD -> beginTime = Instant.ofEpochMilli(parser.longValue())
-                    END_TIME_FIELD -> endTime = Instant.ofEpochMilli(parser.longValue())
-                    TENANT_FIELD -> tenant = parser.text()
-                    ACCESS_LIST_FIELD -> access = parser.stringList()
-                    REPORT_DEFINITION_DETAILS_FIELD -> reportDefinitionDetails = ReportDefinitionDetails.parse(parser)
-                    STATUS_FIELD -> status = Status.valueOf(parser.text())
-                    STATUS_TEXT_FIELD -> statusText = parser.text()
-                    IN_CONTEXT_DOWNLOAD_URL_FIELD -> inContextDownloadUrlPath = parser.text()
+                    ID_FIELD -> {
+                        id = parser.text()
+                    }
+
+                    UPDATED_TIME_FIELD -> {
+                        updatedTime = Instant.ofEpochMilli(parser.longValue())
+                    }
+
+                    CREATED_TIME_FIELD -> {
+                        createdTime = Instant.ofEpochMilli(parser.longValue())
+                    }
+
+                    BEGIN_TIME_FIELD -> {
+                        beginTime = Instant.ofEpochMilli(parser.longValue())
+                    }
+
+                    END_TIME_FIELD -> {
+                        endTime = Instant.ofEpochMilli(parser.longValue())
+                    }
+
+                    TENANT_FIELD -> {
+                        tenant = parser.text()
+                    }
+
+                    ACCESS_LIST_FIELD -> {
+                        access = parser.stringList()
+                    }
+
+                    REPORT_DEFINITION_DETAILS_FIELD -> {
+                        reportDefinitionDetails = ReportDefinitionDetails.parse(parser)
+                    }
+
+                    STATUS_FIELD -> {
+                        status = Status.valueOf(parser.text())
+                    }
+
+                    STATUS_TEXT_FIELD -> {
+                        statusText = parser.text()
+                    }
+
+                    IN_CONTEXT_DOWNLOAD_URL_FIELD -> {
+                        inContextDownloadUrlPath = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:ReportInstance Skipping Unknown field $fieldName")
@@ -125,7 +162,7 @@ internal data class ReportInstance(
                 reportDefinitionDetails,
                 status,
                 statusText,
-                inContextDownloadUrlPath
+                inContextDownloadUrlPath,
             )
         }
     }
@@ -135,20 +172,22 @@ internal data class ReportInstance(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {ref toXContent}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder {
         builder!!
         builder.startObject()
         if (params?.paramAsBoolean(ID_FIELD, false) == true) {
             builder.field(ID_FIELD, id)
         }
-        builder.field(UPDATED_TIME_FIELD, updatedTime.toEpochMilli())
+        builder
+            .field(UPDATED_TIME_FIELD, updatedTime.toEpochMilli())
             .field(CREATED_TIME_FIELD, createdTime.toEpochMilli())
             .field(BEGIN_TIME_FIELD, beginTime.toEpochMilli())
             .field(END_TIME_FIELD, endTime.toEpochMilli())
@@ -158,11 +197,12 @@ internal data class ReportInstance(
         }
         if (reportDefinitionDetails != null) {
             builder.field(REPORT_DEFINITION_DETAILS_FIELD)
-            val passingParams = if (params?.param(ID_FIELD) == null) { // If called from index operation
-                INSTANCE_INDEX_PARAMS
-            } else {
-                params
-            }
+            val passingParams =
+                if (params?.param(ID_FIELD) == null) { // If called from index operation
+                    INSTANCE_INDEX_PARAMS
+                } else {
+                    params
+                }
             reportDefinitionDetails.toXContent(builder, passingParams)
         }
         builder.field(STATUS_FIELD, status.name)

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportInstanceDoc.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportInstanceDoc.kt
@@ -10,5 +10,5 @@ import org.opensearch.index.seqno.SequenceNumbers
 internal data class ReportInstanceDoc(
     val reportInstance: ReportInstance,
     val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
-    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
 )

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportInstanceSearchResults.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportInstanceSearchResults.kt
@@ -18,7 +18,7 @@ internal class ReportInstanceSearchResults : SearchResults<ReportInstance> {
         startIndex: Long,
         totalHits: Long,
         totalHitRelation: TotalHits.Relation,
-        objectList: List<ReportInstance>
+        objectList: List<ReportInstance>,
     ) : super(startIndex, totalHits, totalHitRelation, objectList, REPORT_INSTANCE_LIST_FIELD)
 
     constructor(parser: XContentParser) : super(parser, REPORT_INSTANCE_LIST_FIELD)
@@ -28,7 +28,8 @@ internal class ReportInstanceSearchResults : SearchResults<ReportInstance> {
     /**
      * {@inheritDoc}
      */
-    override fun parseItem(parser: XContentParser, useId: String?): ReportInstance {
-        return ReportInstance.parse(parser, useId)
-    }
+    override fun parseItem(
+        parser: XContentParser,
+        useId: String?,
+    ): ReportInstance = ReportInstance.parse(parser, useId)
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionRequest.kt
@@ -37,7 +37,9 @@ import java.io.IOException
  * }
  * }</pre>
  */
-internal class UpdateReportDefinitionRequest : ActionRequest, ToXContentObject {
+internal class UpdateReportDefinitionRequest :
+    ActionRequest,
+    ToXContentObject {
     val reportDefinitionId: String
     val reportDefinition: ReportDefinition
 
@@ -65,8 +67,14 @@ internal class UpdateReportDefinitionRequest : ActionRequest, ToXContentObject {
             val fieldName = parser.currentName()
             parser.nextToken()
             when (fieldName) {
-                REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
-                REPORT_DEFINITION_FIELD -> reportDefinition = ReportDefinition.parse(parser)
+                REPORT_DEFINITION_ID_FIELD -> {
+                    reportDefinitionId = parser.text()
+                }
+
+                REPORT_DEFINITION_FIELD -> {
+                    reportDefinition = ReportDefinition.parse(parser)
+                }
+
                 else -> {
                     parser.skipChildren()
                     log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -98,24 +106,23 @@ internal class UpdateReportDefinitionRequest : ActionRequest, ToXContentObject {
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .field(REPORT_DEFINITION_FIELD, reportDefinition)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionResponse.kt
@@ -28,12 +28,11 @@ import java.io.IOException
  * }</pre>
  */
 internal class UpdateReportDefinitionResponse(
-    val reportDefinitionId: String?
+    val reportDefinitionId: String?,
 ) : BaseResponse() {
-
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportDefinitionId = input.readString()
+        reportDefinitionId = input.readString(),
     )
 
     companion object {
@@ -51,7 +50,10 @@ internal class UpdateReportDefinitionResponse(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_DEFINITION_ID_FIELD -> reportDefinitionId = parser.text()
+                    REPORT_DEFINITION_ID_FIELD -> {
+                        reportDefinitionId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -77,9 +79,12 @@ internal class UpdateReportDefinitionResponse(
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_DEFINITION_ID_FIELD, reportDefinitionId)
             .endObject()
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusRequest.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusRequest.kt
@@ -40,14 +40,14 @@ import java.io.IOException
 internal class UpdateReportInstanceStatusRequest(
     val reportInstanceId: String,
     var status: Status,
-    var statusText: String? = null
-) : ActionRequest(), ToXContentObject {
-
+    var statusText: String? = null,
+) : ActionRequest(),
+    ToXContentObject {
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
         reportInstanceId = input.readString(),
         status = input.readEnum(Status::class.java),
-        statusText = input.readOptionalString()
+        statusText = input.readOptionalString(),
     )
 
     companion object {
@@ -58,7 +58,10 @@ internal class UpdateReportInstanceStatusRequest(
          * @param parser data referenced at parser
          * @return created [UpdateReportInstanceStatusRequest] object
          */
-        fun parse(parser: XContentParser, useReportInstanceId: String? = null): UpdateReportInstanceStatusRequest {
+        fun parse(
+            parser: XContentParser,
+            useReportInstanceId: String? = null,
+        ): UpdateReportInstanceStatusRequest {
             var reportInstanceId: String? = useReportInstanceId
             var status: Status? = null
             var statusText: String? = null
@@ -67,9 +70,18 @@ internal class UpdateReportInstanceStatusRequest(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_INSTANCE_ID_FIELD -> reportInstanceId = parser.text()
-                    STATUS_FIELD -> status = Status.valueOf(parser.text())
-                    STATUS_TEXT_FIELD -> statusText = parser.text()
+                    REPORT_INSTANCE_ID_FIELD -> {
+                        reportInstanceId = parser.text()
+                    }
+
+                    STATUS_FIELD -> {
+                        status = Status.valueOf(parser.text())
+                    }
+
+                    STATUS_TEXT_FIELD -> {
+                        statusText = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -103,25 +115,24 @@ internal class UpdateReportInstanceStatusRequest(
      * @param params XContent parameters
      * @return created XContentBuilder object
      */
-    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? {
-        return toXContent(XContentFactory.jsonBuilder(), params)
-    }
+    fun toXContent(params: ToXContent.Params = ToXContent.EMPTY_PARAMS): XContentBuilder? = toXContent(XContentFactory.jsonBuilder(), params)
 
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_INSTANCE_ID_FIELD, reportInstanceId)
             .field(STATUS_FIELD, status)
             .fieldIfNotNull(STATUS_TEXT_FIELD, statusText)
             .endObject()
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun validate(): ActionRequestValidationException? {
-        return null
-    }
+    override fun validate(): ActionRequestValidationException? = null
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusResponse.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusResponse.kt
@@ -27,12 +27,11 @@ import java.io.IOException
  * }</pre>
  */
 internal data class UpdateReportInstanceStatusResponse(
-    val reportInstanceId: String
+    val reportInstanceId: String,
 ) : BaseResponse() {
-
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        reportInstanceId = input.readString()
+        reportInstanceId = input.readString(),
     )
 
     companion object {
@@ -50,7 +49,10 @@ internal data class UpdateReportInstanceStatusResponse(
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    REPORT_INSTANCE_ID_FIELD -> reportInstanceId = parser.text()
+                    REPORT_INSTANCE_ID_FIELD -> {
+                        reportInstanceId = parser.text()
+                    }
+
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
@@ -73,9 +75,12 @@ internal data class UpdateReportInstanceStatusResponse(
     /**
      * {@inheritDoc}
      */
-    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        return builder!!.startObject()
+    override fun toXContent(
+        builder: XContentBuilder?,
+        params: ToXContent.Params?,
+    ): XContentBuilder =
+        builder!!
+            .startObject()
             .field(REPORT_INSTANCE_ID_FIELD, reportInstanceId)
             .endObject()
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/OnDemandReportRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/OnDemandReportRestHandler.kt
@@ -38,23 +38,19 @@ internal class OnDemandReportRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return REPORT_INSTANCE_LIST_ACTION
-    }
+    override fun getName(): String = REPORT_INSTANCE_LIST_ACTION
 
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
-        return listOf()
-    }
+    override fun routes(): List<Route> = listOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            /**
+    override fun replacedRoutes(): List<ReplacedRoute> =
+        listOf(
+            /*
              * Create a new report instance from provided definition
              * Request URL: PUT ON_DEMAND_REPORT_URL
              * Request body: Ref [org.opensearch.reportsscheduler.model.InContextReportCreateRequest]
@@ -64,10 +60,9 @@ internal class OnDemandReportRestHandler : PluginBaseHandler() {
                 PUT,
                 ON_DEMAND_REPORT_URL,
                 PUT,
-                LEGACY_ON_DEMAND_REPORT_URL
+                LEGACY_ON_DEMAND_REPORT_URL,
             ),
-
-            /**
+            /*
              * Create a new report from definition and return instance
              * Request URL: POST ON_DEMAND_REPORT_URL/{reportDefinitionId}
              * Request body: Ref [org.opensearch.reportsscheduler.model.OnDemandReportCreateRequest]
@@ -77,47 +72,54 @@ internal class OnDemandReportRestHandler : PluginBaseHandler() {
                 POST,
                 "$ON_DEMAND_REPORT_URL/{$REPORT_DEFINITION_ID_FIELD}",
                 POST,
-                "$LEGACY_ON_DEMAND_REPORT_URL/{$REPORT_DEFINITION_ID_FIELD}"
-            )
+                "$LEGACY_ON_DEMAND_REPORT_URL/{$REPORT_DEFINITION_ID_FIELD}",
+            ),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun responseParams(): Set<String> {
-        return setOf(REPORT_DEFINITION_ID_FIELD)
-    }
+    override fun responseParams(): Set<String> = setOf(REPORT_DEFINITION_ID_FIELD)
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
-        return when (request.method()) {
-            PUT -> RestChannelConsumer {
-                Metrics.REPORT_FROM_DEFINITION_TOTAL.counter.increment()
-                Metrics.REPORT_FROM_DEFINITION_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    InContextReportCreateAction.ACTION_TYPE,
-                    InContextReportCreateRequest(request.contentParserNextToken()),
-                    RestResponseToXContentListener(it)
-                )
+    override fun executeRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer =
+        when (request.method()) {
+            PUT -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_FROM_DEFINITION_TOTAL.counter.increment()
+                    Metrics.REPORT_FROM_DEFINITION_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        InContextReportCreateAction.ACTION_TYPE,
+                        InContextReportCreateRequest(request.contentParserNextToken()),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            POST -> RestChannelConsumer {
-                Metrics.REPORT_FROM_DEFINITION_ID_TOTAL.counter.increment()
-                Metrics.REPORT_FROM_DEFINITION_ID_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    OnDemandReportCreateAction.ACTION_TYPE,
-                    OnDemandReportCreateRequest.parse(
-                        request.contentParserNextToken(),
-                        request.param(REPORT_DEFINITION_ID_FIELD)
-                    ),
-                    RestResponseToXContentListener(it)
-                )
+
+            POST -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_FROM_DEFINITION_ID_TOTAL.counter.increment()
+                    Metrics.REPORT_FROM_DEFINITION_ID_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        OnDemandReportCreateAction.ACTION_TYPE,
+                        OnDemandReportCreateRequest.parse(
+                            request.contentParserNextToken(),
+                            request.param(REPORT_DEFINITION_ID_FIELD),
+                        ),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            else -> RestChannelConsumer {
-                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+
+            else -> {
+                RestChannelConsumer {
+                    it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+                }
             }
         }
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/PluginBaseHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/PluginBaseHandler.kt
@@ -11,15 +11,20 @@ import org.opensearch.rest.RestRequest
 import org.opensearch.transport.client.node.NodeClient
 
 abstract class PluginBaseHandler : BaseRestHandler() {
-
     /**
      * {@inheritDoc}
      */
-    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+    override fun prepareRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer {
         Metrics.REQUEST_TOTAL.counter.increment()
         Metrics.REQUEST_INTERVAL_COUNT.counter.increment()
         return executeRequest(request, client)
     }
 
-    protected abstract fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer
+    protected abstract fun executeRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportDefinitionListRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportDefinitionListRestHandler.kt
@@ -36,23 +36,19 @@ internal class ReportDefinitionListRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return REPORT_DEFINITION_LIST_ACTION
-    }
+    override fun getName(): String = REPORT_DEFINITION_LIST_ACTION
 
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
-        return listOf()
-    }
+    override fun routes(): List<Route> = listOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            /**
+    override fun replacedRoutes(): List<ReplacedRoute> =
+        listOf(
+            /*
              * Get all report definitions (from optional fromIndex)
              * Request URL: GET LIST_REPORT_DEFINITIONS_URL[?[fromIndex=1000]&[maxItems=100]]
              * Request body: None
@@ -62,29 +58,36 @@ internal class ReportDefinitionListRestHandler : PluginBaseHandler() {
                 GET,
                 LIST_REPORT_DEFINITIONS_URL,
                 GET,
-                LEGACY_LIST_REPORT_DEFINITIONS_URL
-            )
+                LEGACY_LIST_REPORT_DEFINITIONS_URL,
+            ),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+    override fun executeRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer {
         val from = request.param(FROM_INDEX_FIELD)?.toIntOrNull() ?: 0
         val maxItems = request.param(MAX_ITEMS_FIELD)?.toIntOrNull() ?: PluginSettings.defaultItemsQueryCount
         return when (request.method()) {
-            GET -> RestChannelConsumer {
-                Metrics.REPORT_DEFINITION_LIST_TOTAL.counter.increment()
-                Metrics.REPORT_DEFINITION_LIST_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    GetAllReportDefinitionsAction.ACTION_TYPE,
-                    GetAllReportDefinitionsRequest(from, maxItems),
-                    RestResponseToXContentListener(it)
-                )
+            GET -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_DEFINITION_LIST_TOTAL.counter.increment()
+                    Metrics.REPORT_DEFINITION_LIST_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        GetAllReportDefinitionsAction.ACTION_TYPE,
+                        GetAllReportDefinitionsRequest(from, maxItems),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            else -> RestChannelConsumer {
-                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+
+            else -> {
+                RestChannelConsumer {
+                    it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+                }
             }
         }
     }
@@ -92,7 +95,5 @@ internal class ReportDefinitionListRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun responseParams(): Set<String> {
-        return setOf(FROM_INDEX_FIELD, MAX_ITEMS_FIELD)
-    }
+    override fun responseParams(): Set<String> = setOf(FROM_INDEX_FIELD, MAX_ITEMS_FIELD)
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportDefinitionRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportDefinitionRestHandler.kt
@@ -44,23 +44,19 @@ internal class ReportDefinitionRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return REPORT_DEFINITION_ACTION
-    }
+    override fun getName(): String = REPORT_DEFINITION_ACTION
 
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
-        return listOf()
-    }
+    override fun routes(): List<Route> = listOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            /**
+    override fun replacedRoutes(): List<ReplacedRoute> =
+        listOf(
+            /*
              * Create a new report definition
              * Request URL: POST REPORT_DEFINITION_URL
              * Request body: Ref [org.opensearch.reportsscheduler.model.CreateReportDefinitionRequest]
@@ -70,9 +66,9 @@ internal class ReportDefinitionRestHandler : PluginBaseHandler() {
                 POST,
                 REPORT_DEFINITION_URL,
                 POST,
-                LEGACY_REPORT_DEFINITION_URL
+                LEGACY_REPORT_DEFINITION_URL,
             ),
-            /**
+            /*
              * Update report definition
              * Request URL: PUT REPORT_DEFINITION_URL/{reportDefinitionId}
              * Request body: Ref [org.opensearch.reportsscheduler.model.UpdateReportDefinitionRequest]
@@ -82,9 +78,9 @@ internal class ReportDefinitionRestHandler : PluginBaseHandler() {
                 PUT,
                 "$REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}",
                 PUT,
-                "$LEGACY_REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}"
+                "$LEGACY_REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}",
             ),
-            /**
+            /*
              * Get a report definition
              * Request URL: GET REPORT_DEFINITION_URL/{reportDefinitionId}
              * Request body: Ref [org.opensearch.reportsscheduler.model.GetReportDefinitionRequest]
@@ -94,9 +90,9 @@ internal class ReportDefinitionRestHandler : PluginBaseHandler() {
                 GET,
                 "$REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}",
                 GET,
-                "$LEGACY_REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}"
+                "$LEGACY_REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}",
             ),
-            /**
+            /*
              * Delete report definition
              * Request URL: DELETE REPORT_DEFINITION_URL/{reportDefinitionId}
              * Request body: Ref [org.opensearch.reportsscheduler.model.DeleteReportDefinitionRequest]
@@ -106,62 +102,75 @@ internal class ReportDefinitionRestHandler : PluginBaseHandler() {
                 DELETE,
                 "$REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}",
                 DELETE,
-                "$LEGACY_REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}"
-            )
+                "$LEGACY_REPORT_DEFINITION_URL/{$REPORT_DEFINITION_ID_FIELD}",
+            ),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun responseParams(): Set<String> {
-        return setOf(REPORT_DEFINITION_ID_FIELD)
-    }
+    override fun responseParams(): Set<String> = setOf(REPORT_DEFINITION_ID_FIELD)
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
-        return when (request.method()) {
-            POST -> RestChannelConsumer {
-                Metrics.REPORT_DEFINITION_CREATE_TOTAL.counter.increment()
-                Metrics.REPORT_DEFINITION_CREATE_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    CreateReportDefinitionAction.ACTION_TYPE,
-                    CreateReportDefinitionRequest(request.contentParserNextToken()),
-                    RestResponseToXContentListener(it)
-                )
+    override fun executeRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer =
+        when (request.method()) {
+            POST -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_DEFINITION_CREATE_TOTAL.counter.increment()
+                    Metrics.REPORT_DEFINITION_CREATE_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        CreateReportDefinitionAction.ACTION_TYPE,
+                        CreateReportDefinitionRequest(request.contentParserNextToken()),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            PUT -> RestChannelConsumer {
-                Metrics.REPORT_DEFINITION_UPDATE_TOTAL.counter.increment()
-                Metrics.REPORT_DEFINITION_UPDATE_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    UpdateReportDefinitionAction.ACTION_TYPE,
-                    UpdateReportDefinitionRequest(request.contentParserNextToken(), request.param(REPORT_DEFINITION_ID_FIELD)),
-                    RestResponseToXContentListener(it)
-                )
+
+            PUT -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_DEFINITION_UPDATE_TOTAL.counter.increment()
+                    Metrics.REPORT_DEFINITION_UPDATE_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        UpdateReportDefinitionAction.ACTION_TYPE,
+                        UpdateReportDefinitionRequest(request.contentParserNextToken(), request.param(REPORT_DEFINITION_ID_FIELD)),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            GET -> RestChannelConsumer {
-                Metrics.REPORT_DEFINITION_INFO_TOTAL.counter.increment()
-                Metrics.REPORT_DEFINITION_INFO_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    GetReportDefinitionAction.ACTION_TYPE,
-                    GetReportDefinitionRequest(request.param(REPORT_DEFINITION_ID_FIELD)),
-                    RestResponseToXContentListener(it)
-                )
+
+            GET -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_DEFINITION_INFO_TOTAL.counter.increment()
+                    Metrics.REPORT_DEFINITION_INFO_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        GetReportDefinitionAction.ACTION_TYPE,
+                        GetReportDefinitionRequest(request.param(REPORT_DEFINITION_ID_FIELD)),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            DELETE -> RestChannelConsumer {
-                Metrics.REPORT_DEFINITION_DELETE_TOTAL.counter.increment()
-                Metrics.REPORT_DEFINITION_DELETE_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    DeleteReportDefinitionAction.ACTION_TYPE,
-                    DeleteReportDefinitionRequest(request.param(REPORT_DEFINITION_ID_FIELD)),
-                    RestResponseToXContentListener(it)
-                )
+
+            DELETE -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_DEFINITION_DELETE_TOTAL.counter.increment()
+                    Metrics.REPORT_DEFINITION_DELETE_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        DeleteReportDefinitionAction.ACTION_TYPE,
+                        DeleteReportDefinitionRequest(request.param(REPORT_DEFINITION_ID_FIELD)),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            else -> RestChannelConsumer {
-                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+
+            else -> {
+                RestChannelConsumer {
+                    it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+                }
             }
         }
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportInstanceListRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportInstanceListRestHandler.kt
@@ -36,23 +36,19 @@ internal class ReportInstanceListRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return REPORT_INSTANCE_LIST_ACTION
-    }
+    override fun getName(): String = REPORT_INSTANCE_LIST_ACTION
 
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
-        return listOf()
-    }
+    override fun routes(): List<Route> = listOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            /**
+    override fun replacedRoutes(): List<ReplacedRoute> =
+        listOf(
+            /*
              * Get all report instances (from optional fromIndex)
              * Request URL: GET LIST_REPORT_INSTANCES_URL[?[fromIndex=1000]&[maxItems=100]]
              * Request body: None
@@ -62,36 +58,41 @@ internal class ReportInstanceListRestHandler : PluginBaseHandler() {
                 GET,
                 LIST_REPORT_INSTANCES_URL,
                 GET,
-                LEGACY_LIST_REPORT_INSTANCES_URL
-            )
+                LEGACY_LIST_REPORT_INSTANCES_URL,
+            ),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun responseParams(): Set<String> {
-        return setOf(FROM_INDEX_FIELD, MAX_ITEMS_FIELD)
-    }
+    override fun responseParams(): Set<String> = setOf(FROM_INDEX_FIELD, MAX_ITEMS_FIELD)
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+    override fun executeRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer {
         val from = request.param(FROM_INDEX_FIELD)?.toIntOrNull() ?: 0
         val maxItems = request.param(MAX_ITEMS_FIELD)?.toIntOrNull() ?: PluginSettings.defaultItemsQueryCount
         return when (request.method()) {
-            GET -> RestChannelConsumer {
-                Metrics.REPORT_INSTANCE_LIST_TOTAL.counter.increment()
-                Metrics.REPORT_INSTANCE_LIST_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    GetAllReportInstancesAction.ACTION_TYPE,
-                    GetAllReportInstancesRequest(from, maxItems),
-                    RestResponseToXContentListener(it)
-                )
+            GET -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_INSTANCE_LIST_TOTAL.counter.increment()
+                    Metrics.REPORT_INSTANCE_LIST_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        GetAllReportInstancesAction.ACTION_TYPE,
+                        GetAllReportInstancesRequest(from, maxItems),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            else -> RestChannelConsumer {
-                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+
+            else -> {
+                RestChannelConsumer {
+                    it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+                }
             }
         }
     }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportInstanceRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportInstanceRestHandler.kt
@@ -38,23 +38,19 @@ internal class ReportInstanceRestHandler : PluginBaseHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return REPORT_INSTANCE_LIST_ACTION
-    }
+    override fun getName(): String = REPORT_INSTANCE_LIST_ACTION
 
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
-        return listOf()
-    }
+    override fun routes(): List<Route> = listOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            /**
+    override fun replacedRoutes(): List<ReplacedRoute> =
+        listOf(
+            /*
              * Update report instance status
              * Request URL: POST REPORT_INSTANCE_URL/{reportInstanceId}
              * Request body: Ref [org.opensearch.reportsscheduler.model.UpdateReportInstanceStatusRequest]
@@ -64,9 +60,9 @@ internal class ReportInstanceRestHandler : PluginBaseHandler() {
                 POST,
                 "$REPORT_INSTANCE_URL/{$REPORT_INSTANCE_ID_FIELD}",
                 POST,
-                "$LEGACY_REPORT_INSTANCE_URL/{$REPORT_INSTANCE_ID_FIELD}"
+                "$LEGACY_REPORT_INSTANCE_URL/{$REPORT_INSTANCE_ID_FIELD}",
             ),
-            /**
+            /*
              * Get a report instance information
              * Request URL: GET REPORT_INSTANCE_URL/{reportInstanceId}
              * Request body: None
@@ -76,44 +72,52 @@ internal class ReportInstanceRestHandler : PluginBaseHandler() {
                 GET,
                 "$REPORT_INSTANCE_URL/{$REPORT_INSTANCE_ID_FIELD}",
                 GET,
-                "$LEGACY_REPORT_INSTANCE_URL/{$REPORT_INSTANCE_ID_FIELD}"
-            )
+                "$LEGACY_REPORT_INSTANCE_URL/{$REPORT_INSTANCE_ID_FIELD}",
+            ),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun responseParams(): Set<String> {
-        return setOf(REPORT_INSTANCE_ID_FIELD)
-    }
+    override fun responseParams(): Set<String> = setOf(REPORT_INSTANCE_ID_FIELD)
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+    override fun executeRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer {
         val reportInstanceId = request.param(REPORT_INSTANCE_ID_FIELD) ?: throw IllegalArgumentException("Must specify id")
         return when (request.method()) {
-            POST -> RestChannelConsumer {
-                Metrics.REPORT_INSTANCE_UPDATE_TOTAL.counter.increment()
-                Metrics.REPORT_INSTANCE_UPDATE_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    UpdateReportInstanceStatusAction.ACTION_TYPE,
-                    UpdateReportInstanceStatusRequest.parse(request.contentParserNextToken(), reportInstanceId),
-                    RestResponseToXContentListener(it)
-                )
+            POST -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_INSTANCE_UPDATE_TOTAL.counter.increment()
+                    Metrics.REPORT_INSTANCE_UPDATE_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        UpdateReportInstanceStatusAction.ACTION_TYPE,
+                        UpdateReportInstanceStatusRequest.parse(request.contentParserNextToken(), reportInstanceId),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            GET -> RestChannelConsumer {
-                Metrics.REPORT_INSTANCE_INFO_TOTAL.counter.increment()
-                Metrics.REPORT_INSTANCE_INFO_INTERVAL_COUNT.counter.increment()
-                client.execute(
-                    GetReportInstanceAction.ACTION_TYPE,
-                    GetReportInstanceRequest(reportInstanceId),
-                    RestResponseToXContentListener(it)
-                )
+
+            GET -> {
+                RestChannelConsumer {
+                    Metrics.REPORT_INSTANCE_INFO_TOTAL.counter.increment()
+                    Metrics.REPORT_INSTANCE_INFO_INTERVAL_COUNT.counter.increment()
+                    client.execute(
+                        GetReportInstanceAction.ACTION_TYPE,
+                        GetReportInstanceRequest(reportInstanceId),
+                        RestResponseToXContentListener(it),
+                    )
+                }
             }
-            else -> RestChannelConsumer {
-                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+
+            else -> {
+                RestChannelConsumer {
+                    it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+                }
             }
         }
     }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportStatsRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/ReportStatsRestHandler.kt
@@ -30,23 +30,19 @@ internal class ReportStatsRestHandler : BaseRestHandler() {
     /**
      * {@inheritDoc}
      */
-    override fun getName(): String {
-        return REPORT_STATS_ACTION
-    }
+    override fun getName(): String = REPORT_STATS_ACTION
 
     /**
      * {@inheritDoc}
      */
-    override fun routes(): List<Route> {
-        return listOf()
-    }
+    override fun routes(): List<Route> = listOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun replacedRoutes(): List<ReplacedRoute> {
-        return listOf(
-            /**
+    override fun replacedRoutes(): List<ReplacedRoute> =
+        listOf(
+            /*
              * Get reporting backend stats
              * Request URL: GET REPORT_STATS_URL
              * Response body derived from: Ref [org.opensearch.reportsscheduler.metrics.Metrics]
@@ -55,31 +51,35 @@ internal class ReportStatsRestHandler : BaseRestHandler() {
                 GET,
                 "$REPORT_STATS_URL",
                 GET,
-                "$LEGACY_REPORT_STATS_URL"
-            )
+                "$LEGACY_REPORT_STATS_URL",
+            ),
         )
-    }
 
     /**
      * {@inheritDoc}
      */
-    override fun responseParams(): Set<String> {
-        return setOf()
-    }
+    override fun responseParams(): Set<String> = setOf()
 
     /**
      * {@inheritDoc}
      */
-    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
-        return when (request.method()) {
+    override fun prepareRequest(
+        request: RestRequest,
+        client: NodeClient,
+    ): RestChannelConsumer =
+        when (request.method()) {
             // TODO: Wrap this into TransportAction
-            GET -> RestChannelConsumer {
-                // it.sendResponse(BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToFlattenedJSON()))
-                it.sendResponse(BytesRestResponse(RestStatus.OK, Metrics.collectToFlattenedJSON()))
+            GET -> {
+                RestChannelConsumer {
+                    // it.sendResponse(BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToFlattenedJSON()))
+                    it.sendResponse(BytesRestResponse(RestStatus.OK, Metrics.collectToFlattenedJSON()))
+                }
             }
-            else -> RestChannelConsumer {
-                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+
+            else -> {
+                RestChannelConsumer {
+                    it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+                }
             }
         }
-    }
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/RestResponseToXContentListener.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/RestResponseToXContentListener.kt
@@ -19,10 +19,15 @@ import org.opensearch.rest.action.RestToXContentListener
  * {@link ToXContent} and automatically builds an XContent based response
  * (wrapping the toXContent in startObject/endObject).
  */
-internal class RestResponseToXContentListener<Response : BaseResponse>(channel: RestChannel) : RestToXContentListener<Response>(
-    channel
-) {
-    override fun buildResponse(response: Response, builder: XContentBuilder?): RestResponse? {
+internal class RestResponseToXContentListener<Response : BaseResponse>(
+    channel: RestChannel,
+) : RestToXContentListener<Response>(
+        channel,
+    ) {
+    override fun buildResponse(
+        response: Response,
+        builder: XContentBuilder?,
+    ): RestResponse? {
         super.buildResponse(response, builder)
 
         Metrics.REQUEST_TOTAL.counter.increment()
@@ -40,7 +45,5 @@ internal class RestResponseToXContentListener<Response : BaseResponse>(channel: 
     /**
      * {@inheritDoc}
      */
-    override fun getStatus(response: Response): RestStatus {
-        return response.getStatus()
-    }
+    override fun getStatus(response: Response): RestStatus = response.getStatus()
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/scheduler/ReportDefinitionJobParser.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/scheduler/ReportDefinitionJobParser.kt
@@ -15,7 +15,11 @@ internal object ReportDefinitionJobParser : ScheduledJobParser {
     /**
      * {@inheritDoc}
      */
-    override fun parse(xContentParser: XContentParser, id: String, jobDocVersion: JobDocVersion): ScheduledJobParameter {
+    override fun parse(
+        xContentParser: XContentParser,
+        id: String,
+        jobDocVersion: JobDocVersion,
+    ): ScheduledJobParameter {
         xContentParser.nextToken()
         return ReportDefinitionDetails.parse(xContentParser, id)
     }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/scheduler/ReportDefinitionJobRunner.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/scheduler/ReportDefinitionJobRunner.kt
@@ -22,7 +22,10 @@ internal object ReportDefinitionJobRunner : ScheduledJobRunner {
     private val log by logger(ReportDefinitionJobRunner::class.java)
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
-    override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {
+    override fun runJob(
+        job: ScheduledJobParameter,
+        context: JobExecutionContext,
+    ) {
         if (job !is ReportDefinitionDetails) {
             log.warn("$LOG_PREFIX:job is not of type ReportDefinitionDetails:${job.javaClass.name}")
             throw IllegalArgumentException("job is not of type ReportDefinitionDetails:${job.javaClass.name}")
@@ -32,17 +35,18 @@ internal object ReportDefinitionJobRunner : ScheduledJobRunner {
             val currentTime = Instant.now()
             val endTime = context.expectedExecutionTime
             val beginTime = endTime.minus(reportDefinitionDetails.reportDefinition.format.duration)
-            val reportInstance = ReportInstance(
-                context.jobId,
-                currentTime,
-                currentTime,
-                beginTime,
-                endTime,
-                job.tenant,
-                job.access,
-                reportDefinitionDetails,
-                ReportInstance.Status.Success
-            ) // TODO: Revert to Scheduled when background job execution supported
+            val reportInstance =
+                ReportInstance(
+                    context.jobId,
+                    currentTime,
+                    currentTime,
+                    beginTime,
+                    endTime,
+                    job.tenant,
+                    job.access,
+                    reportDefinitionDetails,
+                    ReportInstance.Status.Success,
+                ) // TODO: Revert to Scheduled when background job execution supported
             val id = ReportInstancesIndex.createReportInstance(reportInstance)
             if (id == null) {
                 log.warn("$LOG_PREFIX:runJob-job creation failed for $reportInstance")

--- a/src/main/kotlin/org/opensearch/reportsscheduler/security/SecurityAccess.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/security/SecurityAccess.kt
@@ -24,7 +24,9 @@ internal object SecurityAccess {
         SpecialPermission.check()
         return try {
             AccessController.doPrivileged(operation)
-        } catch (@Suppress("SwallowedException") e: PrivilegedActionException) {
+        } catch (
+            @Suppress("SwallowedException") e: PrivilegedActionException,
+        ) {
             throw (e.cause as Exception?)!!
         }
     }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/security/UserAccessManager.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/security/UserAccessManager.kt
@@ -37,7 +37,7 @@ internal object UserAccessManager {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
                 "User name not provided for private tenant access",
-                RestStatus.FORBIDDEN
+                RestStatus.FORBIDDEN,
             )
         }
         if (PluginSettings.isRbacEnabled()) {
@@ -46,7 +46,7 @@ internal object UserAccessManager {
                 Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "User doesn't have backend roles configured. Contact administrator.",
-                    RestStatus.FORBIDDEN
+                    RestStatus.FORBIDDEN,
                 )
             }
         }
@@ -55,12 +55,11 @@ internal object UserAccessManager {
     /**
      * Get tenant info from user object.
      */
-    fun getUserTenant(user: User?): String {
-        return when (val requestedTenant = user?.requestedTenant) {
+    fun getUserTenant(user: User?): String =
+        when (val requestedTenant = user?.requestedTenant) {
             null -> DEFAULT_TENANT
             else -> requestedTenant
         }
-    }
 
     /**
      * Get all user access info from user object.
@@ -111,7 +110,11 @@ internal object UserAccessManager {
     /**
      * validate if user has access based on given access list
      */
-    fun doesUserHasAccess(user: User?, tenant: String, access: List<String>): Boolean {
+    fun doesUserHasAccess(
+        user: User?,
+        tenant: String,
+        access: List<String>,
+    ): Boolean {
         if (user == null) { // Security is disabled
             return true
         }
@@ -128,7 +131,5 @@ internal object UserAccessManager {
         }
     }
 
-    private fun isUserPrivateTenant(user: User?): Boolean {
-        return getUserTenant(user) == PRIVATE_TENANT
-    }
+    private fun isUserPrivateTenant(user: User?): Boolean = getUserTenant(user) == PRIVATE_TENANT
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -21,7 +21,6 @@ import java.io.IOException
  * settings specific to reports scheduler Plugin.
  */
 internal object PluginSettings {
-
     private lateinit var clusterService: ClusterService
 
     /**
@@ -107,42 +106,47 @@ internal object PluginSettings {
         defaultItemsQueryCount = (settings?.get(DEFAULT_ITEMS_QUERY_COUNT_KEY)?.toInt())
             ?: DEFAULT_ITEMS_QUERY_COUNT_VALUE
 
-        defaultSettings = mapOf(
-            OPERATION_TIMEOUT_MS_KEY to operationTimeoutMs.toString(DECIMAL_RADIX),
-            DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX)
-        )
+        defaultSettings =
+            mapOf(
+                OPERATION_TIMEOUT_MS_KEY to operationTimeoutMs.toString(DECIMAL_RADIX),
+                DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX),
+            )
     }
 
-    private val OPERATION_TIMEOUT_MS: Setting<Long> = Setting.longSetting(
-        OPERATION_TIMEOUT_MS_KEY,
-        defaultSettings[OPERATION_TIMEOUT_MS_KEY]!!.toLong(),
-        MINIMUM_OPERATION_TIMEOUT_MS,
-        NodeScope,
-        Dynamic
-    )
+    private val OPERATION_TIMEOUT_MS: Setting<Long> =
+        Setting.longSetting(
+            OPERATION_TIMEOUT_MS_KEY,
+            defaultSettings[OPERATION_TIMEOUT_MS_KEY]!!.toLong(),
+            MINIMUM_OPERATION_TIMEOUT_MS,
+            NodeScope,
+            Dynamic,
+        )
 
-    private val DEFAULT_ITEMS_QUERY_COUNT: Setting<Int> = Setting.intSetting(
-        DEFAULT_ITEMS_QUERY_COUNT_KEY,
-        defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
-        MINIMUM_ITEMS_QUERY_COUNT,
-        NodeScope,
-        Dynamic
-    )
+    private val DEFAULT_ITEMS_QUERY_COUNT: Setting<Int> =
+        Setting.intSetting(
+            DEFAULT_ITEMS_QUERY_COUNT_KEY,
+            defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
+            MINIMUM_ITEMS_QUERY_COUNT,
+            NodeScope,
+            Dynamic,
+        )
 
-    private val LEGACY_FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
-        LEGACY_FILTER_BY_BACKEND_ROLES_KEY,
-        false,
-        NodeScope,
-        Dynamic,
-        Setting.Property.Deprecated
-    )
+    private val LEGACY_FILTER_BY_BACKEND_ROLES: Setting<Boolean> =
+        Setting.boolSetting(
+            LEGACY_FILTER_BY_BACKEND_ROLES_KEY,
+            false,
+            NodeScope,
+            Dynamic,
+            Setting.Property.Deprecated,
+        )
 
-    private val FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
-        FILTER_BY_BACKEND_ROLES_KEY,
-        LEGACY_FILTER_BY_BACKEND_ROLES,
-        NodeScope,
-        Dynamic
-    )
+    private val FILTER_BY_BACKEND_ROLES: Setting<Boolean> =
+        Setting.boolSetting(
+            FILTER_BY_BACKEND_ROLES_KEY,
+            LEGACY_FILTER_BY_BACKEND_ROLES,
+            NodeScope,
+            Dynamic,
+        )
 
     /**
      * Returns true if RBAC is enabled, else false (default false).
@@ -160,12 +164,11 @@ internal object PluginSettings {
      *
      * @return list of settings defined in this plugin
      */
-    fun getAllSettings(): List<Setting<*>> {
-        return listOf(
+    fun getAllSettings(): List<Setting<*>> =
+        listOf(
             OPERATION_TIMEOUT_MS,
-            DEFAULT_ITEMS_QUERY_COUNT
+            DEFAULT_ITEMS_QUERY_COUNT,
         )
-    }
 
     /**
      * Update the setting variables to setting values from local settings

--- a/src/main/kotlin/org/opensearch/reportsscheduler/util/Helpers.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/util/Helpers.kt
@@ -21,9 +21,7 @@ import org.opensearch.reportsscheduler.model.ReportInstance
 import org.opensearch.rest.RestRequest
 import java.net.URI
 
-internal fun StreamInput.createJsonParser(): XContentParser {
-    return XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, this)
-}
+internal fun StreamInput.createJsonParser(): XContentParser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, this)
 
 internal fun RestRequest.contentParserNextToken(): XContentParser {
     val parser = this.contentParser()
@@ -40,18 +38,22 @@ internal fun XContentParser.stringList(): List<String> {
     return retList
 }
 
-internal fun <T : Any> logger(forClass: Class<T>): Lazy<Logger> {
-    return lazy { LogManager.getLogger(forClass) }
-}
+internal fun <T : Any> logger(forClass: Class<T>): Lazy<Logger> = lazy { LogManager.getLogger(forClass) }
 
-internal fun XContentBuilder.fieldIfNotNull(name: String, value: Any?): XContentBuilder {
+internal fun XContentBuilder.fieldIfNotNull(
+    name: String,
+    value: Any?,
+): XContentBuilder {
     if (value != null) {
         this.field(name, value)
     }
     return this
 }
 
-internal fun XContentBuilder.objectIfNotNull(name: String, xContentObject: ToXContentObject?): XContentBuilder {
+internal fun XContentBuilder.objectIfNotNull(
+    name: String,
+    xContentObject: ToXContentObject?,
+): XContentBuilder {
     if (xContentObject != null) {
         this.field(name)
         xContentObject.toXContent(this, ToXContent.EMPTY_PARAMS)
@@ -66,13 +68,20 @@ internal fun XContentBuilder.objectIfNotNull(name: String, xContentObject: ToXCo
  * @param reportInstanceId[String]
  * @return [String] the actual report link
  */
-internal fun buildReportLink(origin: String, tenant: String, reportInstanceId: String): String {
+internal fun buildReportLink(
+    origin: String,
+    tenant: String,
+    reportInstanceId: String,
+): String {
     var tenantValueInUrl = tenant
-    tenantValueInUrl = when (tenant) {
-        "__user__" -> "private"
-        "" -> "global"
-        // Use this as equivalent to Javascript encodeURIComponents() https://stackoverflow.com/a/35294242
-        else -> URI(null, null, tenantValueInUrl, null).rawPath
-    }
+    tenantValueInUrl =
+        when (tenant) {
+            "__user__" -> "private"
+
+            "" -> "global"
+
+            // Use this as equivalent to Javascript encodeURIComponents() https://stackoverflow.com/a/35294242
+            else -> URI(null, null, tenantValueInUrl, null).rawPath
+        }
     return "$origin/app/reports-dashboards?security_tenant=$tenantValueInUrl#/report_details/$reportInstanceId"
 }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/util/SecureIndexClient.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/util/SecureIndexClient.kt
@@ -44,15 +44,21 @@ import org.opensearch.transport.client.Client
  * Wrapper class on [Client] with security context removed.
  */
 @Suppress("TooManyFunctions")
-internal class SecureIndexClient(private val client: Client) : Client by client {
+internal class SecureIndexClient(
+    private val client: Client,
+) : Client by client {
     /**
      * {@inheritDoc}
      */
     override fun <Request : ActionRequest, Response : ActionResponse> execute(
         action: ActionType<Response>,
-        request: Request
+        request: Request,
     ): ActionFuture<Response> {
-        client.threadPool().threadContext.stashContext().use { return client.execute(action, request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.execute(action, request) }
     }
 
     /**
@@ -61,205 +67,363 @@ internal class SecureIndexClient(private val client: Client) : Client by client 
     override fun <Request : ActionRequest, Response : ActionResponse> execute(
         action: ActionType<Response>,
         request: Request,
-        listener: ActionListener<Response>
+        listener: ActionListener<Response>,
     ) {
-        client.threadPool().threadContext.stashContext().use { return client.execute(action, request, listener) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.execute(action, request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun index(request: IndexRequest): ActionFuture<IndexResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.index(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.index(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun index(request: IndexRequest, listener: ActionListener<IndexResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.index(request, listener) }
+    override fun index(
+        request: IndexRequest,
+        listener: ActionListener<IndexResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.index(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun update(request: UpdateRequest): ActionFuture<UpdateResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.update(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.update(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun update(request: UpdateRequest, listener: ActionListener<UpdateResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.update(request, listener) }
+    override fun update(
+        request: UpdateRequest,
+        listener: ActionListener<UpdateResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.update(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun delete(request: DeleteRequest): ActionFuture<DeleteResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.delete(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.delete(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun delete(request: DeleteRequest, listener: ActionListener<DeleteResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.delete(request, listener) }
+    override fun delete(
+        request: DeleteRequest,
+        listener: ActionListener<DeleteResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.delete(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun bulk(request: BulkRequest): ActionFuture<BulkResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.bulk(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.bulk(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun bulk(request: BulkRequest, listener: ActionListener<BulkResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.bulk(request, listener) }
+    override fun bulk(
+        request: BulkRequest,
+        listener: ActionListener<BulkResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.bulk(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun get(request: GetRequest): ActionFuture<GetResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.get(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.get(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun get(request: GetRequest, listener: ActionListener<GetResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.get(request, listener) }
+    override fun get(
+        request: GetRequest,
+        listener: ActionListener<GetResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.get(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun multiGet(request: MultiGetRequest): ActionFuture<MultiGetResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.multiGet(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.multiGet(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun multiGet(request: MultiGetRequest, listener: ActionListener<MultiGetResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.multiGet(request, listener) }
+    override fun multiGet(
+        request: MultiGetRequest,
+        listener: ActionListener<MultiGetResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.multiGet(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun search(request: SearchRequest): ActionFuture<SearchResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.search(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.search(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun search(request: SearchRequest, listener: ActionListener<SearchResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.search(request, listener) }
+    override fun search(
+        request: SearchRequest,
+        listener: ActionListener<SearchResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.search(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun searchScroll(request: SearchScrollRequest): ActionFuture<SearchResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.searchScroll(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.searchScroll(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun searchScroll(request: SearchScrollRequest, listener: ActionListener<SearchResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.searchScroll(request, listener) }
+    override fun searchScroll(
+        request: SearchScrollRequest,
+        listener: ActionListener<SearchResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.searchScroll(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun multiSearch(request: MultiSearchRequest): ActionFuture<MultiSearchResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.multiSearch(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.multiSearch(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun multiSearch(request: MultiSearchRequest, listener: ActionListener<MultiSearchResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.multiSearch(request, listener) }
+    override fun multiSearch(
+        request: MultiSearchRequest,
+        listener: ActionListener<MultiSearchResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.multiSearch(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun termVectors(request: TermVectorsRequest): ActionFuture<TermVectorsResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.termVectors(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.termVectors(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun termVectors(request: TermVectorsRequest, listener: ActionListener<TermVectorsResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.termVectors(request, listener) }
+    override fun termVectors(
+        request: TermVectorsRequest,
+        listener: ActionListener<TermVectorsResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.termVectors(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun multiTermVectors(request: MultiTermVectorsRequest): ActionFuture<MultiTermVectorsResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.multiTermVectors(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.multiTermVectors(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun multiTermVectors(request: MultiTermVectorsRequest, listener: ActionListener<MultiTermVectorsResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.multiTermVectors(request, listener) }
+    override fun multiTermVectors(
+        request: MultiTermVectorsRequest,
+        listener: ActionListener<MultiTermVectorsResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.multiTermVectors(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun explain(request: ExplainRequest): ActionFuture<ExplainResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.explain(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.explain(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun explain(request: ExplainRequest, listener: ActionListener<ExplainResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.explain(request, listener) }
+    override fun explain(
+        request: ExplainRequest,
+        listener: ActionListener<ExplainResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.explain(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun clearScroll(request: ClearScrollRequest): ActionFuture<ClearScrollResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.clearScroll(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.clearScroll(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun clearScroll(request: ClearScrollRequest, listener: ActionListener<ClearScrollResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.clearScroll(request, listener) }
+    override fun clearScroll(
+        request: ClearScrollRequest,
+        listener: ActionListener<ClearScrollResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.clearScroll(request, listener) }
     }
 
     /**
      * {@inheritDoc}
      */
     override fun fieldCaps(request: FieldCapabilitiesRequest): ActionFuture<FieldCapabilitiesResponse> {
-        client.threadPool().threadContext.stashContext().use { return client.fieldCaps(request) }
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.fieldCaps(request) }
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun fieldCaps(request: FieldCapabilitiesRequest, listener: ActionListener<FieldCapabilitiesResponse>) {
-        client.threadPool().threadContext.stashContext().use { return client.fieldCaps(request, listener) }
+    override fun fieldCaps(
+        request: FieldCapabilitiesRequest,
+        listener: ActionListener<FieldCapabilitiesResponse>,
+    ) {
+        client
+            .threadPool()
+            .threadContext
+            .stashContext()
+            .use { return client.fieldCaps(request, listener) }
     }
 
     /**
@@ -292,12 +456,18 @@ internal class SecureIndexClient(private val client: Client) : Client by client 
      * The suppressed exception is added to the list of suppressed exceptions of [cause] exception.
      */
     @Suppress("TooGenericExceptionCaught")
-    private fun ThreadContext.StoredContext.closeFinally(cause: Throwable?) = when (cause) {
-        null -> close()
-        else -> try {
-            close()
-        } catch (closeException: Throwable) {
-            cause.addSuppressed(closeException)
+    private fun ThreadContext.StoredContext.closeFinally(cause: Throwable?) =
+        when (cause) {
+            null -> {
+                close()
+            }
+
+            else -> {
+                try {
+                    close()
+                } catch (closeException: Throwable) {
+                    cause.addSuppressed(closeException)
+                }
+            }
         }
-    }
 }

--- a/src/test/kotlin/org/opensearch/integTest/IntegTestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/integTest/IntegTestHelpers.kt
@@ -14,55 +14,62 @@ import kotlin.test.assertTrue
 private const val DEFAULT_TIME_ACCURACY_SEC = 5L
 
 fun constructReportDefinitionRequest(
-    trigger: String = """
-            "trigger":{
-                "triggerType":"OnDemand"
-            },
+    trigger: String =
         """
-        .trimIndent(),
+        "trigger":{
+            "triggerType":"OnDemand"
+        },
+        """.trimIndent(),
     name: String = "report_definition",
-    delivery: String = ""
-): String {
-    return """
-            {
-                "reportDefinition":{
-                    "name":"$name",
-                    "isEnabled":true,
-                    "source":{
-                        "description":"description",
-                        "type":"Dashboard",
-                        "origin":"localhost:5601",
-                        "id":"id"
-                    },
-                    $trigger
-                    $delivery
-                    "format":{
-                        "duration":"PT1H",
-                        "fileFormat":"Pdf",
-                        "limit":1000,
-                        "header":"optional header",
-                        "footer":"optional footer"
-                    }
-                }
+    delivery: String = "",
+): String =
+    """
+    {
+        "reportDefinition":{
+            "name":"$name",
+            "isEnabled":true,
+            "source":{
+                "description":"description",
+                "type":"Dashboard",
+                "origin":"localhost:5601",
+                "id":"id"
+            },
+            $trigger
+            $delivery
+            "format":{
+                "duration":"PT1H",
+                "fileFormat":"Pdf",
+                "limit":1000,
+                "header":"optional header",
+                "footer":"optional footer"
             }
-            """
-        .trimIndent()
-}
+        }
+    }
+    """.trimIndent()
 
-fun jsonify(text: String): JsonObject {
-    return JsonParser.parseString(text).asJsonObject
-}
+fun jsonify(text: String): JsonObject = JsonParser.parseString(text).asJsonObject
 
-fun validateTimeNearRefTime(time: Instant, refTime: Instant, accuracySeconds: Long) {
+fun validateTimeNearRefTime(
+    time: Instant,
+    refTime: Instant,
+    accuracySeconds: Long,
+) {
     assertTrue(time.plusSeconds(accuracySeconds).isAfter(refTime), "$time + $accuracySeconds > $refTime")
     assertTrue(time.minusSeconds(accuracySeconds).isBefore(refTime), "$time - $accuracySeconds < $refTime")
 }
 
-fun validateTimeRecency(time: Instant, accuracySeconds: Long = DEFAULT_TIME_ACCURACY_SEC) {
+fun validateTimeRecency(
+    time: Instant,
+    accuracySeconds: Long = DEFAULT_TIME_ACCURACY_SEC,
+) {
     validateTimeNearRefTime(time, Instant.now(), accuracySeconds)
 }
 
-fun validateErrorResponse(response: JsonObject, statusCode: Int, errorType: String = "status_exception") {
+fun validateErrorResponse(
+    response: JsonObject,
+    statusCode: Int,
+    errorType: String = "status_exception",
+) {
     Assert.assertNotNull("Error response content should be generated", response)
     val status = response.get("status").asInt
     val error = response.get("error").asJsonObject

--- a/src/test/kotlin/org/opensearch/integTest/ReportsSchedulerPluginIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/ReportsSchedulerPluginIT.kt
@@ -17,19 +17,31 @@ class ReportsSchedulerPluginIT : OpenSearchIntegTestCase() {
     @Ignore
     fun testPluginsAreInstalled() {
         val request = ClusterHealthRequest()
-        val response = client().admin().cluster().health(request).actionGet()
+        val response =
+            client()
+                .admin()
+                .cluster()
+                .health(request)
+                .actionGet()
         assertEquals(ClusterHealthStatus.GREEN, response.status)
         val nodesInfoRequest = NodesInfoRequest()
         nodesInfoRequest.addMetric(NodesInfoRequest.Metric.PLUGINS.metricName())
-        val nodesInfoResponse = client().admin().cluster().nodesInfo(nodesInfoRequest).actionGet()
+        val nodesInfoResponse =
+            client()
+                .admin()
+                .cluster()
+                .nodesInfo(nodesInfoRequest)
+                .actionGet()
         val pluginInfos = nodesInfoResponse.nodes[0].getInfo(PluginsAndModules::class.java).pluginInfos
         assertTrue(
-            pluginInfos.stream()
-                .anyMatch { pluginInfo: PluginInfo -> pluginInfo.name == "opensearch-job-scheduler" }
+            pluginInfos
+                .stream()
+                .anyMatch { pluginInfo: PluginInfo -> pluginInfo.name == "opensearch-job-scheduler" },
         )
         assertTrue(
-            pluginInfos.stream()
-                .anyMatch { pluginInfo: PluginInfo -> pluginInfo.name == "opensearch-reports-scheduler" }
+            pluginInfos
+                .stream()
+                .anyMatch { pluginInfo: PluginInfo -> pluginInfo.name == "opensearch-reports-scheduler" },
         )
     }
 }

--- a/src/test/kotlin/org/opensearch/integTest/bwc/ReportsSchedulerBackwardsCompatibilityIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/bwc/ReportsSchedulerBackwardsCompatibilityIT.kt
@@ -16,7 +16,6 @@ import org.opensearch.rest.RestRequest
 import java.time.Instant
 
 class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
-
     companion object {
         private val CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"))
         private val CLUSTER_NAME = System.getProperty("tests.clustername")
@@ -30,15 +29,15 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
 
     override fun preserveODFEIndicesAfterTest(): Boolean = true
 
-    override fun restClientSettings(): Settings {
-        return Settings.builder()
+    override fun restClientSettings(): Settings =
+        Settings
+            .builder()
             .put(super.restClientSettings())
             // increase the timeout here to 90 seconds to handle long waits for a green
             // cluster health. the waits for green need to be longer than a minute to
             // account for delayed shards
             .put(CLIENT_SOCKET_TIMEOUT, "90s")
             .build()
-    }
 
     @Throws(Exception::class)
     @Suppress("UNCHECKED_CAST")
@@ -54,12 +53,14 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
                     assertTrue(pluginNames.contains("opensearch-job-scheduler"))
                     createBasicReportDefinition()
                 }
+
                 ClusterType.MIXED -> {
                     assertTrue(pluginNames.contains("opensearch-reports-scheduler"))
                     assertTrue(pluginNames.contains("opensearch-job-scheduler"))
                     verifyReportDefinitionExists(LEGACY_BASE_REPORTS_URI)
                     verifyReportInstanceExists(LEGACY_BASE_REPORTS_URI)
                 }
+
                 ClusterType.UPGRADED -> {
                     assertTrue(pluginNames.contains("opensearch-reports-scheduler"))
                     assertTrue(pluginNames.contains("opensearch-job-scheduler"))
@@ -74,23 +75,26 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
     private enum class ClusterType {
         OLD,
         MIXED,
-        UPGRADED;
+        UPGRADED,
+        ;
 
         companion object {
-            fun parse(value: String): ClusterType {
-                return when (value) {
+            fun parse(value: String): ClusterType =
+                when (value) {
                     "old_cluster" -> OLD
                     "mixed_cluster" -> MIXED
                     "upgraded_cluster" -> UPGRADED
                     else -> throw AssertionError("Unknown cluster type: $value")
                 }
-            }
         }
     }
 
-    private fun getPluginUri(): String {
-        return when (CLUSTER_TYPE) {
-            ClusterType.OLD -> "_nodes/$CLUSTER_NAME-0/plugins"
+    private fun getPluginUri(): String =
+        when (CLUSTER_TYPE) {
+            ClusterType.OLD -> {
+                "_nodes/$CLUSTER_NAME-0/plugins"
+            }
+
             ClusterType.MIXED -> {
                 when (System.getProperty("tests.rest.bwcsuite_round")) {
                     "second" -> "_nodes/$CLUSTER_NAME-1/plugins"
@@ -98,14 +102,17 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
                     else -> "_nodes/$CLUSTER_NAME-0/plugins"
                 }
             }
-            ClusterType.UPGRADED -> "_nodes/plugins"
+
+            ClusterType.UPGRADED -> {
+                "_nodes/plugins"
+            }
         }
-    }
 
     @Throws(Exception::class)
     private fun createBasicReportDefinition() {
         val timeStampMillis = Instant.now().toEpochMilli()
-        val trigger = """
+        val trigger =
+            """
             "trigger":{
                 "triggerType":"IntervalSchedule",
                 "schedule":{
@@ -116,16 +123,17 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
                     }
                 }
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionRequest = constructReportDefinitionRequest(trigger)
 
         // legacy test
-        val legacyReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val legacyReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val legacyReportDefinitionId = legacyReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", legacyReportDefinitionId)
         // adding this wait time for the scheduler to create a report instance in the report-instance index,
@@ -136,12 +144,13 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
     @Throws(Exception::class)
     @Suppress("UNCHECKED_CAST")
     private fun verifyReportDefinitionExists(uri: String) {
-        val listReportDefinitions = executeRequest(
-            RestRequest.Method.GET.name,
-            "$uri/definitions",
-            "",
-            RestStatus.OK.status
-        )
+        val listReportDefinitions =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$uri/definitions",
+                "",
+                RestStatus.OK.status,
+            )
         val totalHits = listReportDefinitions.get("totalHits").asInt
         Assert.assertEquals(totalHits, 1)
     }
@@ -149,12 +158,13 @@ class ReportsSchedulerBackwardsCompatibilityIT : PluginRestTestCase() {
     @Throws(Exception::class)
     @Suppress("UNCHECKED_CAST")
     private fun verifyReportInstanceExists(uri: String) {
-        val listReportInstances = executeRequest(
-            RestRequest.Method.GET.name,
-            "$uri/instances",
-            "",
-            RestStatus.OK.status
-        )
+        val listReportInstances =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$uri/instances",
+                "",
+                RestStatus.OK.status,
+            )
         val totalHits = listReportInstances.get("totalHits").asInt
         assertTrue("Actual report instances counts ($totalHits) should be greater than or equal to (1)", totalHits >= 1)
     }

--- a/src/test/kotlin/org/opensearch/integTest/rest/InContextMenuReportGenerationIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/rest/InContextMenuReportGenerationIT.kt
@@ -20,8 +20,10 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
     companion object {
         private const val TEST_REPORT_DEFINITION_ID = "fake-id-123"
     }
+
     fun `test create in-context-menu report`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "beginTimeMs": 1604425466263,
                 "endTimeMs": 1604429066263,
@@ -51,83 +53,86 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("reportInstance should be generated", downloadResponse)
         val reportInstance = downloadResponse.get("reportInstance").asJsonObject
         val reportDefinitionDetails = reportInstance.get("reportDefinitionDetails").asJsonObject
         Assert.assertEquals(
             TEST_REPORT_DEFINITION_ID,
-            reportDefinitionDetails.get("id").asString
+            reportDefinitionDetails.get("id").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("beginTimeMs").asString,
-            reportInstance.get("beginTimeMs").asString
+            reportInstance.get("beginTimeMs").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("endTimeMs").asString,
-            reportInstance.get("endTimeMs").asString
+            reportInstance.get("endTimeMs").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("status").asString,
-            reportInstance.get("status").asString
+            reportInstance.get("status").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("statusText").asString,
-            reportInstance.get("statusText").asString
+            reportInstance.get("statusText").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("inContextDownloadUrlPath").asString,
-            reportInstance.get("inContextDownloadUrlPath").asString
+            reportInstance.get("inContextDownloadUrlPath").asString,
         )
         validateTimeRecency(Instant.ofEpochMilli(reportInstance.get("lastUpdatedTimeMs").asLong))
         validateTimeRecency(Instant.ofEpochMilli(reportInstance.get("createdTimeMs").asLong))
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.OK.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("reportInstance should be generated", legacyDownloadResponse)
         val legacyReportInstance = legacyDownloadResponse.get("reportInstance").asJsonObject
         val legacyReportDefinitionDetails = legacyReportInstance.get("reportDefinitionDetails").asJsonObject
         Assert.assertEquals(
             TEST_REPORT_DEFINITION_ID,
-            legacyReportDefinitionDetails.get("id").asString
+            legacyReportDefinitionDetails.get("id").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("beginTimeMs").asString,
-            legacyReportInstance.get("beginTimeMs").asString
+            legacyReportInstance.get("beginTimeMs").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("endTimeMs").asString,
-            legacyReportInstance.get("endTimeMs").asString
+            legacyReportInstance.get("endTimeMs").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("status").asString,
-            legacyReportInstance.get("status").asString
+            legacyReportInstance.get("status").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("statusText").asString,
-            legacyReportInstance.get("statusText").asString
+            legacyReportInstance.get("statusText").asString,
         )
         Assert.assertEquals(
             jsonify(downloadRequest).get("inContextDownloadUrlPath").asString,
-            legacyReportInstance.get("inContextDownloadUrlPath").asString
+            legacyReportInstance.get("inContextDownloadUrlPath").asString,
         )
         validateTimeRecency(Instant.ofEpochMilli(legacyReportInstance.get("lastUpdatedTimeMs").asLong))
         validateTimeRecency(Instant.ofEpochMilli(legacyReportInstance.get("createdTimeMs").asLong))
     }
 
     fun `test create in-context-menu report from invalid source request`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "beginTimeMs": 1604425466263,
                 "endTimeMs": 1604429066263,
@@ -157,27 +162,30 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(downloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(legacyDownloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
     }
 
     fun `test create in-context-menu report from invalid trigger request`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "beginTimeMs": 1604425466263,
                 "endTimeMs": 1604429066263,
@@ -207,27 +215,30 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(downloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(legacyDownloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
     }
 
     fun `test create in-context-menu report from invalid format request`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "beginTimeMs": 1604425466263,
                 "endTimeMs": 1604429066263,
@@ -256,27 +267,30 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(downloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(legacyDownloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
     }
 
     fun `test create in-context-menu report without time request`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "reportDefinitionDetails": {
                     "id": "$TEST_REPORT_DEFINITION_ID",
@@ -304,27 +318,30 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(downloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(legacyDownloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
     }
 
     fun `test create in-context-menu report without status request`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "beginTimeMs": 1604425466263,
                 "endTimeMs": 1604429066263,
@@ -353,27 +370,30 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(downloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(legacyDownloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
     }
 
     fun `test create in-context-menu report without report definition request`() {
-        val downloadRequest = """
+        val downloadRequest =
+            """
             {
                 "beginTimeMs": 1604425466263,
                 "endTimeMs": 1604429066263,
@@ -386,22 +406,24 @@ class InContextMenuReportGenerationIT : PluginRestTestCase() {
                 "statusText":"statusText",
                 "inContextDownloadUrlPath": "/app/dashboard#view/dashboard-id"
             }
-        """.trimIndent()
-        val downloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+            """.trimIndent()
+        val downloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(downloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
 
         // legacy test
-        val legacyDownloadResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand",
-            downloadRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyDownloadResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand",
+                downloadRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(legacyDownloadResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
     }
 }

--- a/src/test/kotlin/org/opensearch/integTest/rest/OnDemandReportGenerationIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/rest/OnDemandReportGenerationIT.kt
@@ -20,7 +20,8 @@ import java.time.Instant
 
 class OnDemandReportGenerationIT : PluginRestTestCase() {
     fun `test create on-demand report from definition`() {
-        val reportDefinitionRequest = """
+        val reportDefinitionRequest =
+            """
             {
                 "reportDefinition":{
                     "name":"report_definition",
@@ -44,73 +45,88 @@ class OnDemandReportGenerationIT : PluginRestTestCase() {
                     }
                 }
             }
-        """.trimIndent()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("reportInstance should be generated", onDemandResponse)
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportDefinitionDetails = reportInstance.get("reportDefinitionDetails").asJsonObject
         val reportDefinition = reportDefinitionDetails.get("reportDefinition").asJsonObject
         Assert.assertEquals(
             reportDefinitionId,
-            reportDefinitionDetails.get("id").asString
+            reportDefinitionDetails.get("id").asString,
         )
         Assert.assertEquals(
             jsonify(reportDefinitionRequest)
-                .get("reportDefinition").asJsonObject,
-            reportDefinition
+                .get("reportDefinition")
+                .asJsonObject,
+            reportDefinition,
         )
         validateTimeRecency(Instant.ofEpochMilli(reportInstance.get("lastUpdatedTimeMs").asLong))
         validateTimeRecency(Instant.ofEpochMilli(reportInstance.get("createdTimeMs").asLong))
         validateTimeRecency(Instant.ofEpochMilli(reportInstance.get("endTimeMs").asLong))
         validateTimeNearRefTime(
             Instant.ofEpochMilli(reportInstance.get("beginTimeMs").asLong),
-            Instant.now().minus(Duration.parse(reportDefinition.get("format").asJsonObject.get("duration").asString)),
-            3
+            Instant.now().minus(
+                Duration.parse(
+                    reportDefinition
+                        .get("format")
+                        .asJsonObject
+                        .get("duration")
+                        .asString,
+                ),
+            ),
+            3,
         )
         Assert.assertEquals(
             reportInstance.get("tenant").asString,
-            reportDefinitionDetails.get("tenant").asString
+            reportDefinitionDetails.get("tenant").asString,
         )
         Assert.assertEquals(reportInstance.get("status").asString, "Success")
         Assert.assertNull(reportInstance.get("statusText"))
         Assert.assertNull(reportInstance.get("inContextDownloadUrlPath"))
 
         // legacy test
-        val legacyReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val legacyReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val legacyReportDefinitionId = legacyReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", legacyReportDefinitionId)
         Thread.sleep(100)
-        val legacyOnDemandRequest = """
+        val legacyOnDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val legacyOnDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$legacyReportDefinitionId",
-            legacyOnDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val legacyOnDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$legacyReportDefinitionId",
+                legacyOnDemandRequest,
+                RestStatus.OK.status,
+            )
 
         Assert.assertNotNull("reportInstance should be generated", legacyOnDemandResponse)
         val legacyReportInstance = legacyOnDemandResponse.get("reportInstance").asJsonObject
@@ -118,24 +134,33 @@ class OnDemandReportGenerationIT : PluginRestTestCase() {
         val legacyReportDefinition = legacyReportDefinitionDetails.get("reportDefinition").asJsonObject
         Assert.assertEquals(
             legacyReportDefinitionId,
-            legacyReportDefinitionDetails.get("id").asString
+            legacyReportDefinitionDetails.get("id").asString,
         )
         Assert.assertEquals(
             jsonify(reportDefinitionRequest)
-                .get("reportDefinition").asJsonObject,
-            legacyReportDefinition
+                .get("reportDefinition")
+                .asJsonObject,
+            legacyReportDefinition,
         )
         validateTimeRecency(Instant.ofEpochMilli(legacyReportInstance.get("lastUpdatedTimeMs").asLong))
         validateTimeRecency(Instant.ofEpochMilli(legacyReportInstance.get("createdTimeMs").asLong))
         validateTimeRecency(Instant.ofEpochMilli(legacyReportInstance.get("endTimeMs").asLong))
         validateTimeNearRefTime(
             Instant.ofEpochMilli(legacyReportInstance.get("beginTimeMs").asLong),
-            Instant.now().minus(Duration.parse(reportDefinition.get("format").asJsonObject.get("duration").asString)),
-            1
+            Instant.now().minus(
+                Duration.parse(
+                    reportDefinition
+                        .get("format")
+                        .asJsonObject
+                        .get("duration")
+                        .asString,
+                ),
+            ),
+            1,
         )
         Assert.assertEquals(
             legacyReportInstance.get("tenant").asString,
-            reportDefinitionDetails.get("tenant").asString
+            reportDefinitionDetails.get("tenant").asString,
         )
         Assert.assertEquals(legacyReportInstance.get("status").asString, "Success")
         Assert.assertNull(legacyReportInstance.get("statusText"))
@@ -143,7 +168,8 @@ class OnDemandReportGenerationIT : PluginRestTestCase() {
     }
 
     fun `test create on-demand report from invalid definition id`() {
-        val reportDefinitionRequest = """
+        val reportDefinitionRequest =
+            """
             {
                 "reportDefinition":{
                     "name":"report_definition",
@@ -166,46 +192,52 @@ class OnDemandReportGenerationIT : PluginRestTestCase() {
                     }
                 }
             }
-        """.trimIndent()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString + "invalid"
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.NOT_FOUND.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(onDemandResponse, RestStatus.NOT_FOUND.status)
 
         // legacy test
-        val legacyReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val legacyReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val legacyReportDefinitionId = legacyReportDefinitionResponse.get("reportDefinitionId").asString + "invalid"
         Assert.assertNotNull("reportDefinitionId should be generated", legacyReportDefinitionId)
         Thread.sleep(100)
-        val legacyOnDemandRequest = """
+        val legacyOnDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val legacyOnDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$legacyReportDefinitionId",
-            legacyOnDemandRequest,
-            RestStatus.NOT_FOUND.status
-        )
+            """.trimIndent()
+        val legacyOnDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$legacyReportDefinitionId",
+                legacyOnDemandRequest,
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(legacyOnDemandResponse, RestStatus.NOT_FOUND.status)
     }
 }

--- a/src/test/kotlin/org/opensearch/integTest/rest/ReportDefinitionIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/rest/ReportDefinitionIT.kt
@@ -17,242 +17,283 @@ import org.opensearch.rest.RestRequest
 class ReportDefinitionIT : PluginRestTestCase() {
     fun `test create, get, update, delete report definition`() {
         val reportDefinitionOnDemandRequest = constructReportDefinitionRequest()
-        val reportDefinitionOnDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionOnDemandRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionOnDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionOnDemandRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionOnDemandId = reportDefinitionOnDemandResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionOnDemandId)
         Thread.sleep(100)
 
-        val reportDefinitionDownloadRequest = constructReportDefinitionRequest(
-            """
+        val reportDefinitionDownloadRequest =
+            constructReportDefinitionRequest(
+                """
                 "trigger":{
                     "triggerType":"Download"
                 },
-            """.trimIndent()
-        )
-        val reportDefinitionDownloadResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionDownloadRequest,
-            RestStatus.OK.status
-        )
+                """.trimIndent(),
+            )
+        val reportDefinitionDownloadResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionDownloadRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionDownloadId = reportDefinitionDownloadResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionDownloadId)
         Thread.sleep(1000)
 
-        val reportDefinitionsResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definitions",
-            "",
-            RestStatus.OK.status
-        )
+        val reportDefinitionsResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/definitions",
+                "",
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(2, reportDefinitionsResponse.get("totalHits").asInt)
         Thread.sleep(100)
 
         val newName = "updated_report"
         val reportDefinitionUpdateRequest = constructReportDefinitionRequest(name = newName)
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            reportDefinitionUpdateRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                reportDefinitionUpdateRequest,
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(
             reportDefinitionOnDemandId,
-            reportDefinitionUpdateResponse.get("reportDefinitionId").asString
+            reportDefinitionUpdateResponse.get("reportDefinitionId").asString,
         )
         Thread.sleep(100)
 
-        val reportDefinitionGetResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportDefinitionGetResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                "",
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(
             reportDefinitionOnDemandId,
-            reportDefinitionGetResponse.get("reportDefinitionDetails").asJsonObject.get("id").asString
+            reportDefinitionGetResponse
+                .get("reportDefinitionDetails")
+                .asJsonObject
+                .get("id")
+                .asString,
         )
         Assert.assertEquals(
             newName,
-            reportDefinitionGetResponse.get("reportDefinitionDetails").asJsonObject
-                .get("reportDefinition").asJsonObject.get("name").asString
+            reportDefinitionGetResponse
+                .get("reportDefinitionDetails")
+                .asJsonObject
+                .get("reportDefinition")
+                .asJsonObject
+                .get("name")
+                .asString,
         )
         Thread.sleep(100)
 
-        val reportDefinitionDeleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportDefinitionDeleteResponse =
+            executeRequest(
+                RestRequest.Method.DELETE.name,
+                "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                "",
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(
             reportDefinitionOnDemandId,
-            reportDefinitionDeleteResponse.get("reportDefinitionId").asString
+            reportDefinitionDeleteResponse.get("reportDefinitionId").asString,
         )
         Thread.sleep(100)
 
-        val reportDefinitionGetNotFoundResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            "",
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionGetNotFoundResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                "",
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionGetNotFoundResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        val reportDefinitionInvalidGetResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definition/invalid-id",
-            "",
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionInvalidGetResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/definition/invalid-id",
+                "",
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionInvalidGetResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        val reportDefinitionInvalidUpdateResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/definition/invalid-id",
-            constructReportDefinitionRequest(),
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionInvalidUpdateResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$BASE_REPORTS_URI/definition/invalid-id",
+                constructReportDefinitionRequest(),
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionInvalidUpdateResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        val reportDefinitionInvalidDeleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$BASE_REPORTS_URI/definition/invalid-id",
-            "",
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionInvalidDeleteResponse =
+            executeRequest(
+                RestRequest.Method.DELETE.name,
+                "$BASE_REPORTS_URI/definition/invalid-id",
+                "",
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionInvalidDeleteResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
     }
 
     fun `test legacy create, get, update, delete report definition`() {
         val reportDefinitionOnDemandRequest = constructReportDefinitionRequest()
-        val reportDefinitionOnDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionOnDemandRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionOnDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionOnDemandRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionOnDemandId = reportDefinitionOnDemandResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionOnDemandId)
         Thread.sleep(100)
 
-        val reportDefinitionDownloadRequest = constructReportDefinitionRequest(
-            """
+        val reportDefinitionDownloadRequest =
+            constructReportDefinitionRequest(
+                """
                 "trigger":{
                     "triggerType":"Download"
                 },
-            """.trimIndent()
-        )
-        val reportDefinitionDownloadResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionDownloadRequest,
-            RestStatus.OK.status
-        )
+                """.trimIndent(),
+            )
+        val reportDefinitionDownloadResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionDownloadRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionDownloadId = reportDefinitionDownloadResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionDownloadId)
         Thread.sleep(1000)
 
-        val reportDefinitionsResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/definitions",
-            "",
-            RestStatus.OK.status
-        )
+        val reportDefinitionsResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/definitions",
+                "",
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(2, reportDefinitionsResponse.get("totalHits").asInt)
         Thread.sleep(100)
 
         val newName = "updated_report"
         val reportDefinitionUpdateRequest = constructReportDefinitionRequest(name = newName)
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            reportDefinitionUpdateRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                reportDefinitionUpdateRequest,
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(
             reportDefinitionOnDemandId,
-            reportDefinitionUpdateResponse.get("reportDefinitionId").asString
+            reportDefinitionUpdateResponse.get("reportDefinitionId").asString,
         )
         Thread.sleep(100)
 
-        val reportDefinitionGetResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportDefinitionGetResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                "",
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(
             reportDefinitionOnDemandId,
-            reportDefinitionGetResponse.get("reportDefinitionDetails").asJsonObject.get("id").asString
+            reportDefinitionGetResponse
+                .get("reportDefinitionDetails")
+                .asJsonObject
+                .get("id")
+                .asString,
         )
         Assert.assertEquals(
             newName,
-            reportDefinitionGetResponse.get("reportDefinitionDetails").asJsonObject
-                .get("reportDefinition").asJsonObject.get("name").asString
+            reportDefinitionGetResponse
+                .get("reportDefinitionDetails")
+                .asJsonObject
+                .get("reportDefinition")
+                .asJsonObject
+                .get("name")
+                .asString,
         )
         Thread.sleep(100)
 
-        val reportDefinitionDeleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportDefinitionDeleteResponse =
+            executeRequest(
+                RestRequest.Method.DELETE.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                "",
+                RestStatus.OK.status,
+            )
         Assert.assertEquals(
             reportDefinitionOnDemandId,
-            reportDefinitionDeleteResponse.get("reportDefinitionId").asString
+            reportDefinitionDeleteResponse.get("reportDefinitionId").asString,
         )
         Thread.sleep(100)
 
-        val reportDefinitionGetNotFoundResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
-            "",
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionGetNotFoundResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+                "",
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionGetNotFoundResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        val reportDefinitionInvalidGetResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/invalid-id",
-            "",
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionInvalidGetResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/invalid-id",
+                "",
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionInvalidGetResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        val reportDefinitionInvalidUpdateResponse = executeRequest(
-            RestRequest.Method.PUT.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/invalid-id",
-            constructReportDefinitionRequest(),
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionInvalidUpdateResponse =
+            executeRequest(
+                RestRequest.Method.PUT.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/invalid-id",
+                constructReportDefinitionRequest(),
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionInvalidUpdateResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        val reportDefinitionInvalidDeleteResponse = executeRequest(
-            RestRequest.Method.DELETE.name,
-            "$LEGACY_BASE_REPORTS_URI/definition/invalid-id",
-            "",
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionInvalidDeleteResponse =
+            executeRequest(
+                RestRequest.Method.DELETE.name,
+                "$LEGACY_BASE_REPORTS_URI/definition/invalid-id",
+                "",
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionInvalidDeleteResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
     }
 
     fun `test create cron scheduled report definition`() {
-        val trigger = """
+        val trigger =
+            """
             "trigger":{
                 "triggerType":"CronSchedule",
                 "schedule":{
@@ -262,32 +303,35 @@ class ReportDefinitionIT : PluginRestTestCase() {
                     }
                 }
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionRequest = constructReportDefinitionRequest(trigger)
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
 
         // legacy test
-        val legacyReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val legacyReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val legacyReportDefinitionId = legacyReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", legacyReportDefinitionId)
         Thread.sleep(100)
     }
 
     fun `test create interval scheduled report definition`() {
-        val trigger = """
+        val trigger =
+            """
             "trigger":{
                 "triggerType":"IntervalSchedule",
                 "schedule":{
@@ -298,47 +342,52 @@ class ReportDefinitionIT : PluginRestTestCase() {
                     }
                 }
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionRequest = constructReportDefinitionRequest(trigger)
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
 
         // legacy test
-        val legacyReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val legacyReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val legacyReportDefinitionId = legacyReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", legacyReportDefinitionId)
         Thread.sleep(100)
     }
 
     fun `test create invalid cron scheduled report definition`() {
-        val cronTrigger = """
+        val cronTrigger =
+            """
             "trigger":{
                 "triggerType":"CronSchedule"
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionCronRequest = constructReportDefinitionRequest(cronTrigger)
-        val reportDefinitionCronResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionCronRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val reportDefinitionCronResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionCronRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(reportDefinitionCronResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
         Thread.sleep(100)
 
-        val invalidCronTrigger = """
+        val invalidCronTrigger =
+            """
             "trigger":{
                 "triggerType":"CronSchedule",
                 "schedule":{
@@ -348,71 +397,77 @@ class ReportDefinitionIT : PluginRestTestCase() {
                     }
                 }
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionInvalidCronRequest = constructReportDefinitionRequest(invalidCronTrigger)
-        val reportDefinitionInvalidCronResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionInvalidCronRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val reportDefinitionInvalidCronResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionInvalidCronRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             reportDefinitionInvalidCronResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
         Thread.sleep(100)
 
         // legacy test
-        val legacyReportDefinitionInvalidCronResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionInvalidCronRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyReportDefinitionInvalidCronResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionInvalidCronRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             legacyReportDefinitionInvalidCronResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
         Thread.sleep(100)
     }
 
     fun `test create invalid interval scheduled report definition`() {
-        val intervalTrigger = """
+        val intervalTrigger =
+            """
             "trigger":{
                 "triggerType":"IntervalSchedule"
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionIntervalRequest = constructReportDefinitionRequest(intervalTrigger)
-        val reportDefinitionIntervalResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionIntervalRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val reportDefinitionIntervalResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionIntervalRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             reportDefinitionIntervalResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
         Thread.sleep(100)
 
         // legacy test
-        val legacyReportDefinitionIntervalResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionIntervalRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyReportDefinitionIntervalResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionIntervalRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             legacyReportDefinitionIntervalResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
         Thread.sleep(100)
 
-        val invalidIntervalTrigger = """
+        val invalidIntervalTrigger =
+            """
             "trigger":{
                 "triggerType":"IntervalSchedule",
                 "schedule":{
@@ -420,115 +475,123 @@ class ReportDefinitionIT : PluginRestTestCase() {
                     }
                 }
             },
-        """.trimIndent()
+            """.trimIndent()
         val reportDefinitionInvalidIntervalRequest = constructReportDefinitionRequest(invalidIntervalTrigger)
-        val reportDefinitionInvalidIntervalResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionInvalidIntervalRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val reportDefinitionInvalidIntervalResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionInvalidIntervalRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             reportDefinitionInvalidIntervalResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
         Thread.sleep(100)
 
         // legacy test
-        val legacyReportDefinitionInvalidIntervalResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionInvalidIntervalRequest,
-            RestStatus.BAD_REQUEST.status
-        )
+        val legacyReportDefinitionInvalidIntervalResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionInvalidIntervalRequest,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             legacyReportDefinitionInvalidIntervalResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
         Thread.sleep(100)
     }
 
     fun `test listing multiple report definitions`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
 
         val secondReportDefinitionRequest = constructReportDefinitionRequest(name = "new report definition")
-        val secondReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            secondReportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val secondReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                secondReportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val newReportDefinitionId = secondReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", newReportDefinitionId)
         Thread.sleep(1000)
-        val listReportDefinitions = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definitions",
-            "",
-            RestStatus.OK.status
-        )
+        val listReportDefinitions =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/definitions",
+                "",
+                RestStatus.OK.status,
+            )
         val totalHits = listReportDefinitions.get("totalHits").asInt
         Assert.assertEquals(2, totalHits)
         val reportDefinitionsList = listReportDefinitions.get("reportDefinitionDetailsList").asJsonArray
         Assert.assertEquals(
             reportDefinitionId,
-            reportDefinitionsList[0].asJsonObject.get("id").asString
+            reportDefinitionsList[0].asJsonObject.get("id").asString,
         )
         Assert.assertEquals(
             newReportDefinitionId,
-            reportDefinitionsList[1].asJsonObject.get("id").asString
+            reportDefinitionsList[1].asJsonObject.get("id").asString,
         )
     }
 
     fun `test legacy listing multiple report definitions`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
 
         val secondReportDefinitionRequest = constructReportDefinitionRequest(name = "new report definition")
-        val secondReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            secondReportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val secondReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                secondReportDefinitionRequest,
+                RestStatus.OK.status,
+            )
         val newReportDefinitionId = secondReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", newReportDefinitionId)
         Thread.sleep(1000)
-        val listReportDefinitions = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/definitions",
-            "",
-            RestStatus.OK.status
-        )
+        val listReportDefinitions =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/definitions",
+                "",
+                RestStatus.OK.status,
+            )
         val totalHits = listReportDefinitions.get("totalHits").asInt
         Assert.assertEquals(totalHits, 2)
         val reportDefinitionsList = listReportDefinitions.get("reportDefinitionDetailsList").asJsonArray
         Assert.assertEquals(
             reportDefinitionId,
-            reportDefinitionsList[0].asJsonObject.get("id").asString
+            reportDefinitionsList[0].asJsonObject.get("id").asString,
         )
         Assert.assertEquals(
             newReportDefinitionId,
-            reportDefinitionsList[1].asJsonObject.get("id").asString
+            reportDefinitionsList[1].asJsonObject.get("id").asString,
         )
     }
 }

--- a/src/test/kotlin/org/opensearch/integTest/rest/ReportInstanceIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/rest/ReportInstanceIT.kt
@@ -17,511 +17,563 @@ import org.opensearch.rest.RestRequest
 class ReportInstanceIT : PluginRestTestCase() {
     fun `test update on-demand report definition status to success after creation`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
 
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "status":"Success",
                 "statusText":"Operation completed"
             }
-        """.trimIndent()
+            """.trimIndent()
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/instance/$reportInstanceId",
-            updateStatus,
-            RestStatus.OK.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/instance/$reportInstanceId",
+                updateStatus,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("report definition should be updated", reportDefinitionUpdateResponse)
         Assert.assertEquals(
             reportInstanceId,
-            reportDefinitionUpdateResponse.get("reportInstanceId").asString
+            reportDefinitionUpdateResponse.get("reportInstanceId").asString,
         )
-        val reportInstanceInfo = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/instance/$reportInstanceId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportInstanceInfo =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/instance/$reportInstanceId",
+                "",
+                RestStatus.OK.status,
+            )
         val updatedReportInstance = reportInstanceInfo.get("reportInstance").asJsonObject
         val updatedReportInstanceStatus = updatedReportInstance.get("status").asString
         val updatedReportInstanceText = updatedReportInstance.get("statusText").asString
         Assert.assertEquals(
             "Success",
-            updatedReportInstanceStatus
+            updatedReportInstanceStatus,
         )
         Assert.assertEquals(
             "Operation completed",
-            updatedReportInstanceText
+            updatedReportInstanceText,
         )
     }
 
     fun `test update report instance status to failed after creation`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
 
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "status":"Failed",
                 "statusText":"Operation failed"
             }
-        """.trimIndent()
+            """.trimIndent()
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/instance/$reportInstanceId",
-            updateStatus,
-            RestStatus.OK.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/instance/$reportInstanceId",
+                updateStatus,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("report definition should be updated", reportDefinitionUpdateResponse)
         Assert.assertEquals(
             reportInstanceId,
-            reportDefinitionUpdateResponse.get("reportInstanceId").asString
+            reportDefinitionUpdateResponse.get("reportInstanceId").asString,
         )
-        val reportInstanceInfo = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/instance/$reportInstanceId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportInstanceInfo =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/instance/$reportInstanceId",
+                "",
+                RestStatus.OK.status,
+            )
         val updatedReportInstance = reportInstanceInfo.get("reportInstance").asJsonObject
         val updatedReportInstanceStatus = updatedReportInstance.get("status").asString
         val updatedReportInstanceText = updatedReportInstance.get("statusText").asString
         Assert.assertEquals(
             "Failed",
-            updatedReportInstanceStatus
+            updatedReportInstanceStatus,
         )
         Assert.assertEquals(
             "Operation failed",
-            updatedReportInstanceText
+            updatedReportInstanceText,
         )
     }
 
     fun `test update report instance status with invalid instance id`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "status":"Success",
                 "statusText":"Operation completed"
             }
-        """.trimIndent()
+            """.trimIndent()
 
         val dummyInstanceId = "abcdefghijk123"
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/instance/$dummyInstanceId",
-            updateStatus,
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/instance/$dummyInstanceId",
+                updateStatus,
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionUpdateResponse, RestStatus.NOT_FOUND.status)
     }
 
     fun `test update report instance status with invalid update status`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
 
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "invalidStatus":"Success",
                 "statusText":"Operation completed"
             }
-        """.trimIndent()
+            """.trimIndent()
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
 
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/instance/$reportInstanceId",
-            updateStatus,
-            RestStatus.BAD_REQUEST.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/instance/$reportInstanceId",
+                updateStatus,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             reportDefinitionUpdateResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
     }
 
     fun `test listing all report instances`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
 
         val addReportDefinition = constructReportDefinitionRequest(name = "new definition")
-        val addReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/definition",
-            addReportDefinition,
-            RestStatus.OK.status
-        )
+        val addReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/definition",
+                addReportDefinition,
+                RestStatus.OK.status,
+            )
         val newReportDefinitionId = addReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", newReportDefinitionId)
 
-        val newOnDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$BASE_REPORTS_URI/on_demand/$newReportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+        val newOnDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$BASE_REPORTS_URI/on_demand/$newReportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
         val newReportInstance = newOnDemandResponse.get("reportInstance").asJsonObject
         val newReportInstanceId = newReportInstance.get("id").asString
         Thread.sleep(1000)
-        val listReportInstancesResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/instances",
-            "",
-            RestStatus.OK.status
-        )
+        val listReportInstancesResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_REPORTS_URI/instances",
+                "",
+                RestStatus.OK.status,
+            )
         val totalHits = listReportInstancesResponse.get("totalHits").asInt
         Assert.assertEquals(totalHits, 2)
         val reportInstanceList = listReportInstancesResponse.get("reportInstanceList").asJsonArray
         Assert.assertEquals(
             reportInstanceId,
-            reportInstanceList[0].asJsonObject.get("id").asString
+            reportInstanceList[0].asJsonObject.get("id").asString,
         )
         Assert.assertEquals(
             newReportInstanceId,
-            reportInstanceList[1].asJsonObject.get("id").asString
+            reportInstanceList[1].asJsonObject.get("id").asString,
         )
     }
 
     fun `test opendistro legacy update on-demand report definition status to success after creation`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
 
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "status":"Success",
                 "statusText":"Operation completed"
             }
-        """.trimIndent()
+            """.trimIndent()
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
-            updateStatus,
-            RestStatus.OK.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
+                updateStatus,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("report definition should be updated", reportDefinitionUpdateResponse)
         Assert.assertEquals(
             reportInstanceId,
-            reportDefinitionUpdateResponse.get("reportInstanceId").asString
+            reportDefinitionUpdateResponse.get("reportInstanceId").asString,
         )
-        val reportInstanceInfo = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportInstanceInfo =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
+                "",
+                RestStatus.OK.status,
+            )
         val updatedReportInstance = reportInstanceInfo.get("reportInstance").asJsonObject
         val updatedReportInstanceStatus = updatedReportInstance.get("status").asString
         val updatedReportInstanceText = updatedReportInstance.get("statusText").asString
         Assert.assertEquals(
             "Success",
-            updatedReportInstanceStatus
+            updatedReportInstanceStatus,
         )
         Assert.assertEquals(
             "Operation completed",
-            updatedReportInstanceText
+            updatedReportInstanceText,
         )
     }
 
     fun `test opendistro legacy update report instance status to failed after creation`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
 
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "status":"Failed",
                 "statusText":"Operation failed"
             }
-        """.trimIndent()
+            """.trimIndent()
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
-            updateStatus,
-            RestStatus.OK.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
+                updateStatus,
+                RestStatus.OK.status,
+            )
         Assert.assertNotNull("report definition should be updated", reportDefinitionUpdateResponse)
         Assert.assertEquals(
             reportInstanceId,
-            reportDefinitionUpdateResponse.get("reportInstanceId").asString
+            reportDefinitionUpdateResponse.get("reportInstanceId").asString,
         )
-        val reportInstanceInfo = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
-            "",
-            RestStatus.OK.status
-        )
+        val reportInstanceInfo =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
+                "",
+                RestStatus.OK.status,
+            )
         val updatedReportInstance = reportInstanceInfo.get("reportInstance").asJsonObject
         val updatedReportInstanceStatus = updatedReportInstance.get("status").asString
         val updatedReportInstanceText = updatedReportInstance.get("statusText").asString
         Assert.assertEquals(
             "Failed",
-            updatedReportInstanceStatus
+            updatedReportInstanceStatus,
         )
         Assert.assertEquals(
             "Operation failed",
-            updatedReportInstanceText
+            updatedReportInstanceText,
         )
     }
 
     fun `test opendistro legacy update report instance status with invalid instance id`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "status":"Success",
                 "statusText":"Operation completed"
             }
-        """.trimIndent()
+            """.trimIndent()
 
         val dummyInstanceId = "abcdefghijk123"
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/instance/$dummyInstanceId",
-            updateStatus,
-            RestStatus.NOT_FOUND.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/instance/$dummyInstanceId",
+                updateStatus,
+                RestStatus.NOT_FOUND.status,
+            )
         validateErrorResponse(reportDefinitionUpdateResponse, RestStatus.NOT_FOUND.status)
     }
 
     fun `test opendistro legacy update report instance status with invalid update status`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
 
-        val updateStatus = """
+        val updateStatus =
+            """
             {
                 "invalidStatus":"Success",
                 "statusText":"Operation completed"
             }
-        """.trimIndent()
+            """.trimIndent()
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
 
-        val reportDefinitionUpdateResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
-            updateStatus,
-            RestStatus.BAD_REQUEST.status
-        )
+        val reportDefinitionUpdateResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/instance/$reportInstanceId",
+                updateStatus,
+                RestStatus.BAD_REQUEST.status,
+            )
         validateErrorResponse(
             reportDefinitionUpdateResponse,
             RestStatus.BAD_REQUEST.status,
-            "illegal_argument_exception"
+            "illegal_argument_exception",
         )
     }
 
     fun `test opendistro legacy listing all report instances`() {
         val reportDefinitionRequest = constructReportDefinitionRequest()
-        val reportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
-            RestStatus.OK.status
-        )
+        val reportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                reportDefinitionRequest,
+                RestStatus.OK.status,
+            )
 
         val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
         Thread.sleep(100)
-        val onDemandRequest = """
+        val onDemandRequest =
+            """
             {}
-        """.trimIndent()
-        val onDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+            """.trimIndent()
+        val onDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$reportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
         val reportInstance = onDemandResponse.get("reportInstance").asJsonObject
         val reportInstanceId = reportInstance.get("id").asString
 
         val addReportDefinition = constructReportDefinitionRequest(name = "new definition")
-        val addReportDefinitionResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/definition",
-            addReportDefinition,
-            RestStatus.OK.status
-        )
+        val addReportDefinitionResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/definition",
+                addReportDefinition,
+                RestStatus.OK.status,
+            )
         val newReportDefinitionId = addReportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", newReportDefinitionId)
 
-        val newOnDemandResponse = executeRequest(
-            RestRequest.Method.POST.name,
-            "$LEGACY_BASE_REPORTS_URI/on_demand/$newReportDefinitionId",
-            onDemandRequest,
-            RestStatus.OK.status
-        )
+        val newOnDemandResponse =
+            executeRequest(
+                RestRequest.Method.POST.name,
+                "$LEGACY_BASE_REPORTS_URI/on_demand/$newReportDefinitionId",
+                onDemandRequest,
+                RestStatus.OK.status,
+            )
         val newReportInstance = newOnDemandResponse.get("reportInstance").asJsonObject
         val newReportInstanceId = newReportInstance.get("id").asString
         Thread.sleep(1000)
-        val listReportInstancesResponse = executeRequest(
-            RestRequest.Method.GET.name,
-            "$LEGACY_BASE_REPORTS_URI/instances",
-            "",
-            RestStatus.OK.status
-        )
+        val listReportInstancesResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$LEGACY_BASE_REPORTS_URI/instances",
+                "",
+                RestStatus.OK.status,
+            )
         val totalHits = listReportInstancesResponse.get("totalHits").asInt
         Assert.assertEquals(totalHits, 2)
         val reportInstanceList = listReportInstancesResponse.get("reportInstanceList").asJsonArray
         Assert.assertEquals(
             reportInstanceId,
-            reportInstanceList[0].asJsonObject.get("id").asString
+            reportInstanceList[0].asJsonObject.get("id").asString,
         )
         Assert.assertEquals(
             newReportInstanceId,
-            reportInstanceList[1].asJsonObject.get("id").asString
+            reportInstanceList[1].asJsonObject.get("id").asString,
         )
     }
 }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/TestHelpers.kt
@@ -29,36 +29,41 @@ fun getJsonString(xContent: ToXContent): String {
 
 inline fun <reified CreateType> createObjectFromJsonString(
     jsonString: String,
-    block: (XContentParser) -> CreateType
+    block: (XContentParser) -> CreateType,
 ): CreateType {
-    val parser = XContentType.JSON.xContent()
-        .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, jsonString)
+    val parser =
+        XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, jsonString)
     parser.nextToken()
     return block(parser)
 }
 
 internal fun createReportDefinitionObject(): ReportDefinition {
-    val source = ReportDefinition.Source(
-        description = "description",
-        type = ReportDefinition.SourceType.Dashboard,
-        origin = "http://localhost:5601",
-        id = "id"
-    )
+    val source =
+        ReportDefinition.Source(
+            description = "description",
+            type = ReportDefinition.SourceType.Dashboard,
+            origin = "http://localhost:5601",
+            id = "id",
+        )
 
-    val format = ReportDefinition.Format(
-        duration = Duration.parse("PT1H"),
-        fileFormat = ReportDefinition.FileFormat.Pdf,
-        limit = 1000,
-        header = "optional header",
-        footer = "optional footer",
-        timeFrom = null,
-        timeTo = null
-    )
+    val format =
+        ReportDefinition.Format(
+            duration = Duration.parse("PT1H"),
+            fileFormat = ReportDefinition.FileFormat.Pdf,
+            limit = 1000,
+            header = "optional header",
+            footer = "optional footer",
+            timeFrom = null,
+            timeTo = null,
+        )
 
-    val trigger = ReportDefinition.Trigger(
-        triggerType = ReportDefinition.TriggerType.OnDemand,
-        schedule = null
-    )
+    val trigger =
+        ReportDefinition.Trigger(
+            triggerType = ReportDefinition.TriggerType.OnDemand,
+            schedule = null,
+        )
 
     return ReportDefinition(
         name = "sample_report_definition",
@@ -66,12 +71,12 @@ internal fun createReportDefinitionObject(): ReportDefinition {
         source = source,
         format = format,
         trigger = trigger,
-        delivery = null
+        delivery = null,
     )
 }
 
-internal fun createReportInstance(): ReportInstance {
-    return ReportInstance(
+internal fun createReportInstance(): ReportInstance =
+    ReportInstance(
         "id",
         Instant.ofEpochMilli(1603506908773),
         Instant.ofEpochMilli(1603506908773),
@@ -82,17 +87,15 @@ internal fun createReportInstance(): ReportInstance {
         null,
         ReportInstance.Status.Success,
         statusText = "200",
-        inContextDownloadUrlPath = "/app/dashboard#view/dashboard-id"
+        inContextDownloadUrlPath = "/app/dashboard#view/dashboard-id",
     )
-}
 
-internal fun createReportDefinitionDetails(): ReportDefinitionDetails {
-    return ReportDefinitionDetails(
+internal fun createReportDefinitionDetails(): ReportDefinitionDetails =
+    ReportDefinitionDetails(
         "id",
         Instant.ofEpochMilli(1603506908773),
         Instant.ofEpochMilli(1603506908773),
         "__user__",
         listOf(),
-        reportDefinition = createReportDefinitionObject()
+        reportDefinition = createReportDefinitionObject(),
     )
-}

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionRequestTests.kt
@@ -14,12 +14,12 @@ import org.opensearch.reportsscheduler.createReportDefinitionObject
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class CreateReportDefinitionRequestTests {
-
     @Test
     fun `Create request serialize and deserialize using json object should be equal`() {
-        val reportDefinitionRequest = CreateReportDefinitionRequest(
-            createReportDefinitionObject()
-        )
+        val reportDefinitionRequest =
+            CreateReportDefinitionRequest(
+                createReportDefinitionObject(),
+            )
         val jsonString = getJsonString(reportDefinitionRequest)
         val recreatedObject = createObjectFromJsonString(jsonString) { CreateReportDefinitionRequest(it) }
         Assertions.assertEquals(reportDefinitionRequest.reportDefinition, recreatedObject.reportDefinition)
@@ -28,7 +28,8 @@ internal class CreateReportDefinitionRequestTests {
     @Test
     fun `Create request should deserialize json object using parser`() {
         val reportDefinitionObject = createReportDefinitionObject()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportDefinition":{
                     "name":"sample_report_definition",
@@ -51,7 +52,7 @@ internal class CreateReportDefinitionRequestTests {
                     }
                 }
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { CreateReportDefinitionRequest(it) }
         Assertions.assertEquals(reportDefinitionObject, recreatedObject.reportDefinition)
     }
@@ -67,7 +68,8 @@ internal class CreateReportDefinitionRequestTests {
     @Test
     fun `Create request should safely ignore extra field in json object`() {
         val reportDefinitionObject = createReportDefinitionObject()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportDefinition":{
                     "name":"sample_report_definition",
@@ -93,7 +95,7 @@ internal class CreateReportDefinitionRequestTests {
                 "extra_field_2":{"extra":"value"},
                 "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
 
         val recreatedObject = createObjectFromJsonString(jsonString) { CreateReportDefinitionRequest(it) }
         Assertions.assertEquals(reportDefinitionObject, recreatedObject.reportDefinition)

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/CreateReportDefinitionResponseTests.kt
@@ -14,7 +14,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class CreateReportDefinitionResponseTests {
-
     @Test
     fun `Create response serialize and deserialize transport object should be equal`() {
         val reportDefinitionResponse = CreateReportDefinitionResponse("sample_report_definition_id")
@@ -57,14 +56,15 @@ internal class CreateReportDefinitionResponseTests {
     @Test
     fun `Create response should safely ignore extra field in json object`() {
         val reportDefinitionId = "report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { CreateReportDefinitionResponse.parse(it) }
         Assertions.assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionRequestTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class DeleteReportDefinitionRequestTests {
-
     @Test
     fun `Delete request serialize and deserialize using json object should be equal`() {
         val deleteRequest = DeleteReportDefinitionRequest("sample_report_definition_id")
@@ -25,11 +24,12 @@ internal class DeleteReportDefinitionRequestTests {
     @Test
     fun `Delete request should deserialize json object using parser`() {
         val reportDefinitionId = "sample_report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { DeleteReportDefinitionRequest.parse(it) }
         assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }
@@ -45,14 +45,15 @@ internal class DeleteReportDefinitionRequestTests {
     @Test
     fun `Delete request should safely ignore extra field in json object`() {
         val reportDefinitionId = "sample_report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { DeleteReportDefinitionRequest.parse(it) }
         assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/DeleteReportDefinitionResponseTests.kt
@@ -14,7 +14,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class DeleteReportDefinitionResponseTests {
-
     @Test
     fun `Delete response serialize and deserialize transport object should be equal`() {
         val deleteRequest = DeleteReportDefinitionResponse("sample_report_definition_id")
@@ -33,11 +32,12 @@ internal class DeleteReportDefinitionResponseTests {
     @Test
     fun `Delete response should deserialize json object using parser`() {
         val reportDefinitionId = "sample_report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { DeleteReportDefinitionResponse.parse(it) }
         assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }
@@ -53,14 +53,15 @@ internal class DeleteReportDefinitionResponseTests {
     @Test
     fun `Delete response should safely ignore extra field in json object`() {
         val reportDefinitionId = "sample_report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { DeleteReportDefinitionResponse.parse(it) }
         assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsRequestTests.kt
@@ -27,12 +27,13 @@ internal class GetAllReportDefinitionsRequestTests {
 
     @Test
     fun `Get request should deserialize json object using parser`() {
-        val jsonString = """
-        {
-            "fromIndex": $sampleFromIndex,
-            "maxItems": $sampleMaxItems
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "fromIndex": $sampleFromIndex,
+                "maxItems": $sampleMaxItems
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportDefinitionsRequest.parse(it) }
         assertEquals(sampleFromIndex, recreatedObject.fromIndex)
         assertEquals(sampleMaxItems, recreatedObject.maxItems)
@@ -48,15 +49,16 @@ internal class GetAllReportDefinitionsRequestTests {
 
     @Test
     fun `Get request should safely ignore extra field in json object`() {
-        val jsonString = """
-        {
-            "fromIndex": $sampleFromIndex,
-            "maxItems": $sampleMaxItems,
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "fromIndex": $sampleFromIndex,
+                "maxItems": $sampleMaxItems,
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportDefinitionsRequest.parse(it) }
         assertEquals(sampleFromIndex, recreatedObject.fromIndex)
         assertEquals(sampleMaxItems, recreatedObject.maxItems)

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportDefinitionsResponseTests.kt
@@ -14,15 +14,13 @@ import org.opensearch.reportsscheduler.createReportDefinitionDetails
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class GetAllReportDefinitionsResponseTests {
-
-    private fun createReportDefinitionDetailsSearchResults(): ReportDefinitionDetailsSearchResults {
-        return ReportDefinitionDetailsSearchResults(
+    private fun createReportDefinitionDetailsSearchResults(): ReportDefinitionDetailsSearchResults =
+        ReportDefinitionDetailsSearchResults(
             startIndex = 0,
             totalHits = 100,
             totalHitRelation = TotalHits.Relation.EQUAL_TO,
-            objectList = listOf(createReportDefinitionDetails())
+            objectList = listOf(createReportDefinitionDetails()),
         )
-    }
 
     @Test
     fun `Get response serialize and deserialize using json object should be equal`() {
@@ -32,14 +30,15 @@ internal class GetAllReportDefinitionsResponseTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportDefinitionsResponse(it) }
         Assertions.assertEquals(
             response.reportDefinitionList.objectList,
-            recreatedObject.reportDefinitionList.objectList
+            recreatedObject.reportDefinitionList.objectList,
         )
     }
 
     @Test
     fun `Get response should deserialize json object using parser`() {
         val reportDefinitionDetailsSearchResults = createReportDefinitionDetailsSearchResults()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "startIndex":"0",
                 "totalHits":"100",
@@ -74,7 +73,7 @@ internal class GetAllReportDefinitionsResponseTests {
                 }
                ]
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportDefinitionsResponse(it) }
         Assertions.assertEquals(reportDefinitionDetailsSearchResults.objectList, recreatedObject.reportDefinitionList.objectList)
     }
@@ -90,7 +89,8 @@ internal class GetAllReportDefinitionsResponseTests {
     @Test
     fun `Get response should safely ignore extra field in json object`() {
         val reportDefinitionDetailsSearchResults = createReportDefinitionDetailsSearchResults()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "startIndex":"0",
                 "totalHits":"100",
@@ -128,7 +128,7 @@ internal class GetAllReportDefinitionsResponseTests {
               "extra_field_2":{"extra":"value"},
               "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportDefinitionsResponse(it) }
         Assertions.assertEquals(reportDefinitionDetailsSearchResults.objectList, recreatedObject.reportDefinitionList.objectList)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesRequestTests.kt
@@ -26,12 +26,13 @@ internal class GetAllReportInstancesRequestTests {
 
     @Test
     fun `Get request should deserialize json object using parser`() {
-        val jsonString = """
-        {
-            "fromIndex": $sampleFromIndex,
-            "maxItems": $sampleMaxItems
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "fromIndex": $sampleFromIndex,
+                "maxItems": $sampleMaxItems
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportInstancesRequest.parse(it) }
         assertEquals(sampleFromIndex, recreatedObject.fromIndex)
         assertEquals(sampleMaxItems, recreatedObject.maxItems)
@@ -47,15 +48,16 @@ internal class GetAllReportInstancesRequestTests {
 
     @Test
     fun `Get request should safely ignore extra field in json object`() {
-        val jsonString = """
-        {
-            "fromIndex": $sampleFromIndex,
-            "maxItems": $sampleMaxItems,
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "fromIndex": $sampleFromIndex,
+                "maxItems": $sampleMaxItems,
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportInstancesRequest.parse(it) }
         assertEquals(sampleFromIndex, recreatedObject.fromIndex)
         assertEquals(sampleMaxItems, recreatedObject.maxItems)

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesResponseTests.kt
@@ -14,15 +14,13 @@ import org.opensearch.reportsscheduler.createReportInstance
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class GetAllReportInstancesResponseTests {
-
-    private fun createReportInstanceSearchResults(): ReportInstanceSearchResults {
-        return ReportInstanceSearchResults(
+    private fun createReportInstanceSearchResults(): ReportInstanceSearchResults =
+        ReportInstanceSearchResults(
             startIndex = 0,
             totalHits = 100,
             totalHitRelation = TotalHits.Relation.EQUAL_TO,
-            objectList = listOf(createReportInstance())
+            objectList = listOf(createReportInstance()),
         )
-    }
 
     @Test
     fun `Get response serialize and deserialize using json object should be equal`() {
@@ -32,14 +30,15 @@ internal class GetAllReportInstancesResponseTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportInstancesResponse(it) }
         Assertions.assertEquals(
             response.reportInstanceList.objectList,
-            recreatedObject.reportInstanceList.objectList
+            recreatedObject.reportInstanceList.objectList,
         )
     }
 
     @Test
     fun `Get response should deserialize json object using parser`() {
         val reportInstanceSearchResults = createReportInstanceSearchResults()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "startIndex":"0",
                 "totalHits":"100",
@@ -59,7 +58,7 @@ internal class GetAllReportInstancesResponseTests {
                    }
                ]
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportInstancesResponse(it) }
         Assertions.assertEquals(reportInstanceSearchResults.objectList, recreatedObject.reportInstanceList.objectList)
     }
@@ -75,7 +74,8 @@ internal class GetAllReportInstancesResponseTests {
     @Test
     fun `Get response should safely ignore extra field in json object`() {
         val reportInstanceSearchResults = createReportInstanceSearchResults()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "startIndex":"0",
                 "totalHits":"100",
@@ -98,7 +98,7 @@ internal class GetAllReportInstancesResponseTests {
               "extra_field_2":{"extra":"value"},
               "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetAllReportInstancesResponse(it) }
         Assertions.assertEquals(reportInstanceSearchResults.objectList, recreatedObject.reportInstanceList.objectList)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionRequestTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class GetReportDefinitionRequestTests {
-
     @Test
     fun `Get request serialize and deserialize transport object should be equal`() {
         val request = GetReportDefinitionRequest("sample_report_definition_id")
@@ -56,14 +55,15 @@ internal class GetReportDefinitionRequestTests {
     @Test
     fun `Get request should safely ignore extra field in json object`() {
         val reportDefinitionId = "report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportDefinitionRequest.parse(it) }
         assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportDefinitionResponseTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createReportDefinitionDetails
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class GetReportDefinitionResponseTests {
-
     @Test
     fun `Get response serialize and deserialize using json object should be equal`() {
         val reportDefinitionDetails = createReportDefinitionDetails()
@@ -26,7 +25,8 @@ internal class GetReportDefinitionResponseTests {
     @Test
     fun `Get response should deserialize json object using parser`() {
         val reportDefinitionDetails = createReportDefinitionDetails()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportDefinitionDetails":
                 {
@@ -57,7 +57,7 @@ internal class GetReportDefinitionResponseTests {
                     }
                 }
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportDefinitionResponse(it) }
         assertEquals(reportDefinitionDetails, recreatedObject.reportDefinitionDetails)
     }
@@ -73,7 +73,8 @@ internal class GetReportDefinitionResponseTests {
     @Test
     fun `Get response should safely ignore extra field in json object`() {
         val reportDefinitionDetails = createReportDefinitionDetails()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportDefinitionDetails":
                 {
@@ -107,7 +108,7 @@ internal class GetReportDefinitionResponseTests {
                 "extra_field_2":{"extra":"value"},
                 "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportDefinitionResponse(it) }
         assertEquals(reportDefinitionDetails, recreatedObject.reportDefinitionDetails)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceRequestTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class GetReportInstanceRequestTests {
-
     @Test
     fun `Get request serialize and deserialize transport object should be equal`() {
         val request = GetReportInstanceRequest("sample_report_instance_id")
@@ -56,14 +55,15 @@ internal class GetReportInstanceRequestTests {
     @Test
     fun `Get request should safely ignore extra field in json object`() {
         val reportInstanceId = "report_definition_id"
-        val jsonString = """
-        {
-            "reportInstanceId":"$reportInstanceId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportInstanceId":"$reportInstanceId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportInstanceRequest.parse(it) }
         Assertions.assertEquals(reportInstanceId, recreatedObject.reportInstanceId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetReportInstanceResponseTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createReportInstance
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class GetReportInstanceResponseTests {
-
     @Test
     fun `Get response serialize and deserialize using json object should be equal`() {
         val reportInstance = createReportInstance()
@@ -22,14 +21,15 @@ internal class GetReportInstanceResponseTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportInstanceResponse(it) }
         Assertions.assertEquals(
             response.reportInstance,
-            recreatedObject.reportInstance
+            recreatedObject.reportInstance,
         )
     }
 
     @Test
     fun `Get response should deserialize json object using parser`() {
         val reportInstance = createReportInstance()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportInstance": 
                 {
@@ -45,7 +45,7 @@ internal class GetReportInstanceResponseTests {
                    "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id"
                }
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportInstanceResponse(it) }
         Assertions.assertEquals(reportInstance, recreatedObject.reportInstance)
     }
@@ -61,7 +61,8 @@ internal class GetReportInstanceResponseTests {
     @Test
     fun `Get response should safely ignore extra field in json object`() {
         val reportInstance = createReportInstance()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportInstance": 
                 {
@@ -80,7 +81,7 @@ internal class GetReportInstanceResponseTests {
                "extra_field_2":{"extra":"value"},
                "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetReportInstanceResponse(it) }
         Assertions.assertEquals(reportInstance, recreatedObject.reportInstance)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateRequestTests.kt
@@ -14,16 +14,20 @@ import org.opensearch.reportsscheduler.getJsonString
 import java.time.Instant
 
 internal class InContextReportCreateRequestTests {
-    private val request = InContextReportCreateRequest(
-        beginTime = Instant.ofEpochMilli(1603506908773),
-        endTime = Instant.ofEpochMilli(1603506908773),
-        reportDefinitionDetails = null,
-        status = ReportInstance.Status.Success,
-        statusText = "200",
-        inContextDownloadUrlPath = "/app/dashboard#view/dashboard-id"
-    )
+    private val request =
+        InContextReportCreateRequest(
+            beginTime = Instant.ofEpochMilli(1603506908773),
+            endTime = Instant.ofEpochMilli(1603506908773),
+            reportDefinitionDetails = null,
+            status = ReportInstance.Status.Success,
+            statusText = "200",
+            inContextDownloadUrlPath = "/app/dashboard#view/dashboard-id",
+        )
 
-    private fun verify(request: InContextReportCreateRequest, recreatedObject: InContextReportCreateRequest) {
+    private fun verify(
+        request: InContextReportCreateRequest,
+        recreatedObject: InContextReportCreateRequest,
+    ) {
         Assertions.assertEquals(request.beginTime, recreatedObject.beginTime)
         Assertions.assertEquals(request.endTime, recreatedObject.endTime)
         Assertions.assertEquals(request.reportDefinitionDetails, recreatedObject.reportDefinitionDetails)
@@ -41,15 +45,16 @@ internal class InContextReportCreateRequestTests {
 
     @Test
     fun `Create request should deserialize json object using parser`() {
-        val jsonString = """
-         {
-               "beginTimeMs":1603506908773,
-               "endTimeMs":1603506908773,
-               "status": "Success",
-               "statusText":"200",
-               "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id"
-         }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                  "beginTimeMs":1603506908773,
+                  "endTimeMs":1603506908773,
+                  "status": "Success",
+                  "statusText":"200",
+                  "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { InContextReportCreateRequest(it) }
         verify(request, recreatedObject)
     }
@@ -64,18 +69,19 @@ internal class InContextReportCreateRequestTests {
 
     @Test
     fun `Create request should safely ignore extra field in json object`() {
-        val jsonString = """
-        {
-            "beginTimeMs":1603506908773,
-            "endTimeMs":1603506908773,
-            "status": "Success",
-            "statusText":"200",
-            "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "beginTimeMs":1603506908773,
+                "endTimeMs":1603506908773,
+                "status": "Success",
+                "statusText":"200",
+                "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
 
         val recreatedObject = createObjectFromJsonString(jsonString) { InContextReportCreateRequest(it) }
         verify(request, recreatedObject)

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/InContextReportCreateResponseTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createReportInstance
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class InContextReportCreateResponseTests {
-
     @Test
     fun `Create response serialize and deserialize using json object should be equal`() {
         val reportInstance = createReportInstance()
@@ -22,14 +21,15 @@ internal class InContextReportCreateResponseTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { InContextReportCreateResponse(it) }
         Assertions.assertEquals(
             response.reportInstance,
-            recreatedObject.reportInstance
+            recreatedObject.reportInstance,
         )
     }
 
     @Test
     fun `Create response should deserialize json object using parser`() {
         val reportInstance = createReportInstance()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportInstance": 
                 {
@@ -45,7 +45,7 @@ internal class InContextReportCreateResponseTests {
                    "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id"
                }
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { InContextReportCreateResponse(it) }
         Assertions.assertEquals(reportInstance, recreatedObject.reportInstance)
     }
@@ -61,7 +61,8 @@ internal class InContextReportCreateResponseTests {
     @Test
     fun `Create response should safely ignore extra field in json object`() {
         val reportInstance = createReportInstance()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportInstance": 
                 {
@@ -80,7 +81,7 @@ internal class InContextReportCreateResponseTests {
                "extra_field_2":{"extra":"value"},
                "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { InContextReportCreateResponse(it) }
         Assertions.assertEquals(reportInstance, recreatedObject.reportInstance)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateRequestTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class OnDemandReportCreateRequestTests {
-
     @Test
     fun `Create request serialize and deserialize using json object should be equal`() {
         val deleteRequest = OnDemandReportCreateRequest("sample_report_definition_id")
@@ -25,11 +24,12 @@ internal class OnDemandReportCreateRequestTests {
     @Test
     fun `Create request should deserialize json object using parser`() {
         val reportDefinitionId = "sample_report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { OnDemandReportCreateRequest.parse(it) }
         Assertions.assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }
@@ -45,14 +45,15 @@ internal class OnDemandReportCreateRequestTests {
     @Test
     fun `Create request should safely ignore extra field in json object`() {
         val reportDefinitionId = "sample_report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { OnDemandReportCreateRequest.parse(it) }
         Assertions.assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/OnDemandReportCreateResponseTests.kt
@@ -21,14 +21,15 @@ internal class OnDemandReportCreateResponseTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { OnDemandReportCreateResponse(it) }
         Assertions.assertEquals(
             response.reportInstance,
-            recreatedObject.reportInstance
+            recreatedObject.reportInstance,
         )
     }
 
     @Test
     fun `Create response should deserialize json object using parser`() {
         val reportInstance = createReportInstance()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportInstance": 
                 {
@@ -44,7 +45,7 @@ internal class OnDemandReportCreateResponseTests {
                    "inContextDownloadUrlPath":"/app/dashboard#view/dashboard-id"
                }
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { OnDemandReportCreateResponse(it) }
         Assertions.assertEquals(reportInstance, recreatedObject.reportInstance)
     }
@@ -60,7 +61,8 @@ internal class OnDemandReportCreateResponseTests {
     @Test
     fun `Create response should safely ignore extra field in json object`() {
         val reportInstance = createReportInstance()
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportInstance": 
                 {
@@ -79,7 +81,7 @@ internal class OnDemandReportCreateResponseTests {
                "extra_field_2":{"extra":"value"},
                "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { OnDemandReportCreateResponse(it) }
         Assertions.assertEquals(reportInstance, recreatedObject.reportInstance)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionRequestTests.kt
@@ -14,11 +14,11 @@ import org.opensearch.reportsscheduler.createReportDefinitionObject
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class UpdateReportDefinitionRequestTests {
-
-    private val reportDefinitionRequest = UpdateReportDefinitionRequest(
-        "sample_report_definition_id",
-        createReportDefinitionObject()
-    )
+    private val reportDefinitionRequest =
+        UpdateReportDefinitionRequest(
+            "sample_report_definition_id",
+            createReportDefinitionObject(),
+        )
 
     @Test
     fun `Update request serialize and deserialize using json object should be equal`() {
@@ -29,7 +29,8 @@ internal class UpdateReportDefinitionRequestTests {
 
     @Test
     fun `Update request should deserialize json object using parser`() {
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportDefinitionId": "sample_report_definition_id",
                 "reportDefinition":{
@@ -53,7 +54,7 @@ internal class UpdateReportDefinitionRequestTests {
                     }
                 }
             }
-        """.trimIndent()
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { UpdateReportDefinitionRequest(it) }
         Assertions.assertEquals(reportDefinitionRequest.reportDefinition, recreatedObject.reportDefinition)
     }
@@ -68,7 +69,8 @@ internal class UpdateReportDefinitionRequestTests {
 
     @Test
     fun `Update request should safely ignore extra field in json object`() {
-        val jsonString = """
+        val jsonString =
+            """
             {
                 "reportDefinitionId": "sample_report_definition_id",
                 "reportDefinition":{
@@ -95,7 +97,7 @@ internal class UpdateReportDefinitionRequestTests {
                 "extra_field_2":{"extra":"value"},
                 "extra_field_3":"extra value 3"
             }
-        """.trimIndent()
+            """.trimIndent()
 
         val recreatedObject = createObjectFromJsonString(jsonString) { UpdateReportDefinitionRequest(it) }
         Assertions.assertEquals(reportDefinitionRequest.reportDefinition, recreatedObject.reportDefinition)

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportDefinitionResponseTests.kt
@@ -55,14 +55,15 @@ internal class UpdateReportDefinitionResponseTests {
     @Test
     fun `Update response should safely ignore extra field in json object`() {
         val reportDefinitionId = "report_definition_id"
-        val jsonString = """
-        {
-            "reportDefinitionId":"$reportDefinitionId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportDefinitionId":"$reportDefinitionId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { UpdateReportDefinitionResponse.parse(it) }
         Assertions.assertEquals(reportDefinitionId, recreatedObject.reportDefinitionId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusRequestTests.kt
@@ -12,13 +12,17 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class UpdateReportInstanceStatusRequestTests {
-    private val request = UpdateReportInstanceStatusRequest(
-        reportInstanceId = "sample_report_instance_id",
-        status = ReportInstance.Status.Success,
-        statusText = "200"
-    )
+    private val request =
+        UpdateReportInstanceStatusRequest(
+            reportInstanceId = "sample_report_instance_id",
+            status = ReportInstance.Status.Success,
+            statusText = "200",
+        )
 
-    private fun verify(request: UpdateReportInstanceStatusRequest, recreatedObject: UpdateReportInstanceStatusRequest) {
+    private fun verify(
+        request: UpdateReportInstanceStatusRequest,
+        recreatedObject: UpdateReportInstanceStatusRequest,
+    ) {
         Assertions.assertEquals(request.reportInstanceId, recreatedObject.reportInstanceId)
         Assertions.assertEquals(request.status, recreatedObject.status)
         Assertions.assertEquals(request.statusText, recreatedObject.statusText)
@@ -33,13 +37,14 @@ internal class UpdateReportInstanceStatusRequestTests {
 
     @Test
     fun `Create request should deserialize json object using parser`() {
-        val jsonString = """
-         {
-               "reportInstanceId":"sample_report_instance_id",
-               "status": "Success",
-               "statusText":"200"
-         }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                  "reportInstanceId":"sample_report_instance_id",
+                  "status": "Success",
+                  "statusText":"200"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { UpdateReportInstanceStatusRequest.parse(it) }
         verify(request, recreatedObject)
     }
@@ -54,16 +59,17 @@ internal class UpdateReportInstanceStatusRequestTests {
 
     @Test
     fun `Create request should safely ignore extra field in json object`() {
-        val jsonString = """
-        {
-            "reportInstanceId":"sample_report_instance_id",
-            "status": "Success",
-            "statusText":"200",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportInstanceId":"sample_report_instance_id",
+                "status": "Success",
+                "statusText":"200",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
 
         val recreatedObject = createObjectFromJsonString(jsonString) { UpdateReportInstanceStatusRequest.parse(it) }
         verify(request, recreatedObject)

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/UpdateReportInstanceStatusResponseTests.kt
@@ -13,7 +13,6 @@ import org.opensearch.reportsscheduler.createObjectFromJsonString
 import org.opensearch.reportsscheduler.getJsonString
 
 internal class UpdateReportInstanceStatusResponseTests {
-
     @Test
     fun `Update response serialize and deserialize transport object should be equal`() {
         val response = UpdateReportInstanceStatusResponse("sample_report_instance_id")
@@ -56,14 +55,15 @@ internal class UpdateReportInstanceStatusResponseTests {
     @Test
     fun `Update response should safely ignore extra field in json object`() {
         val reportInstanceId = "report_instance_id"
-        val jsonString = """
-        {
-            "reportInstanceId":"$reportInstanceId",
-            "extra_field_1":["extra", "value"],
-            "extra_field_2":{"extra":"value"},
-            "extra_field_3":"extra value 3"
-        }
-        """.trimIndent()
+        val jsonString =
+            """
+            {
+                "reportInstanceId":"$reportInstanceId",
+                "extra_field_1":["extra", "value"],
+                "extra_field_2":{"extra":"value"},
+                "extra_field_3":"extra value 3"
+            }
+            """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { UpdateReportInstanceStatusResponse.parse(it) }
         Assertions.assertEquals(reportInstanceId, recreatedObject.reportInstanceId)
     }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/util/HelpersTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/util/HelpersTests.kt
@@ -17,7 +17,7 @@ internal class HelpersTests {
     fun `test build report link works with global tenant`() {
         assertEquals(
             "$sampleOrigin/app/reports-dashboards?security_tenant=global#/report_details/$sampleId",
-            buildReportLink(sampleOrigin, sampleTenant, sampleId)
+            buildReportLink(sampleOrigin, sampleTenant, sampleId),
         )
     }
 
@@ -26,7 +26,7 @@ internal class HelpersTests {
         sampleTenant = "__user__"
         assertEquals(
             "$sampleOrigin/app/reports-dashboards?security_tenant=private#/report_details/$sampleId",
-            buildReportLink(sampleOrigin, sampleTenant, sampleId)
+            buildReportLink(sampleOrigin, sampleTenant, sampleId),
         )
     }
 
@@ -36,7 +36,7 @@ internal class HelpersTests {
         val reportLink = buildReportLink(sampleOrigin, sampleTenant, sampleId)
         assertEquals(
             "$sampleOrigin/app/reports-dashboards?security_tenant=custom%20name#/report_details/$sampleId",
-            reportLink
+            reportLink,
         )
     }
 }


### PR DESCRIPTION
### Description

Similar to https://github.com/opensearch-project/alerting/pull/1996, but this PR updates the dependency that is bringing an outdated version of logback-core in.

In order to update this dependency I needed to fix all errors from `./gradlew ktlintFormat` which included:

- Suppressing warnings with bad variable names
- Wrapping long strings in multiple lines
- Creating values into actual constants

A lot of files are touched since `./gradlew ktlintFormat` will auto-format the code.

com.pinterest:ktlint is no longer supported and was moved: https://mvnrepository.com/artifact/com.pinterest/ktlint

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
