### PR TITLE
[2.19] Fix maven snapshot publication on 2.19 branch

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - '1.3'
-      - 2.x
+      - 2.*
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
### Description

Fixes maven snapshot publication on 2.19 branch.

Needed to resolve bwc issues seen on main.

### Related Issues

Fixes failing checks on https://github.com/opensearch-project/reporting/pull/1160

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
