### PR TITLE
Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -222,6 +223,7 @@ allprojects {
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-rootProject.name = 'opensearch-reports-scheduler'
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
 
+rootProject.name = 'opensearch-reports-scheduler'


### PR DESCRIPTION
### Description

Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins, such as integration tests run against release candidates during the release process.

### Changes
- `settings.gradle` — Add `pluginManagement` block with CI mirror before Gradle Plugin Portal and Maven Central
- `build.gradle` — Add CI mirror before Maven Central for dependency resolution

### Testing
- Verified `./gradlew assemble` completes successfully
- Ran `git diff --check`