### PR TITLE
fix(cve): bump assertj-core to 3.27.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
 
     testImplementation(
-            'org.assertj:assertj-core:3.16.1',
+            'org.assertj:assertj-core:3.27.7',
             'org.junit.jupiter:junit-jupiter-api:5.6.2'
     )
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')


### PR DESCRIPTION
Fixes CVE-2026-24400 (HIGH) - XML External Entity (XXE) vulnerability in assertj-core when parsing untrusted XML via isXmlEqualTo assertion.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
