### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
@@ -168,6 +169,7 @@ allprojects {
 
 repositories {
     mavenLocal()
+    maven { url = "https://ci.opensearch.org/maven2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-reports-scheduler'
 


### PR DESCRIPTION
### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.

### Changes
* `build.gradle` — Add CI mirror before mavenCentral in repositories blocks
* `settings.gradle` — Add `pluginManagement` block with CI mirror

### Testing
Build verification