### PR TITLE
fix: Accept nullable ResourceSharingClient to prevent NPE on feature …

### DIFF
--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerExtension.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerExtension.kt
@@ -28,7 +28,7 @@ class ReportsSchedulerExtension : ResourceSharingExtension {
         )
     }
 
-    override fun assignResourceSharingClient(resourceSharingClient: ResourceSharingClient) {
+    override fun assignResourceSharingClient(resourceSharingClient: ResourceSharingClient?) {
         ResourceSharingClientAccessor.getInstance()
             .setResourceSharingClient(resourceSharingClient)
     }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resources/ResourceSharingClientAccessor.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resources/ResourceSharingClientAccessor.kt
@@ -11,7 +11,7 @@ class ResourceSharingClientAccessor private constructor() {
 
     private var client: ResourceSharingClient? = null
 
-    fun setResourceSharingClient(client: ResourceSharingClient) {
+    fun setResourceSharingClient(client: ResourceSharingClient?) {
         this.client = client
     }
 

--- a/src/test/kotlin/org/opensearch/reportsscheduler/resources/ResourceSharingClientAccessorTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/resources/ResourceSharingClientAccessorTests.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.reportsscheduler.resources
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.opensearch.reportsscheduler.ReportsSchedulerExtension
+import org.opensearch.security.spi.resources.client.ResourceSharingClient
+
+class ResourceSharingClientAccessorTests {
+
+    private lateinit var accessor: ResourceSharingClientAccessor
+
+    @BeforeEach
+    fun setUp() {
+        accessor = ResourceSharingClientAccessor.getInstance()
+        // Reset state between tests
+        accessor.setResourceSharingClient(null)
+    }
+
+    @Test
+    fun `setResourceSharingClient accepts non-null client`() {
+        val mockClient = mock(ResourceSharingClient::class.java)
+        assertDoesNotThrow { accessor.setResourceSharingClient(mockClient) }
+        assertEquals(mockClient, accessor.getResourceSharingClient())
+    }
+
+    @Test
+    fun `setResourceSharingClient accepts null to clear the client`() {
+        val mockClient = mock(ResourceSharingClient::class.java)
+        accessor.setResourceSharingClient(mockClient)
+        assertNotNull(accessor.getResourceSharingClient())
+
+        assertDoesNotThrow { accessor.setResourceSharingClient(null) }
+        assertNull(accessor.getResourceSharingClient())
+    }
+
+    @Test
+    fun `assignResourceSharingClient does not throw NPE when called with null`() {
+        // This test validates the fix for the NPE that crashes the master election loop.
+        // When the resource-sharing feature flag is disabled, the security plugin calls
+        // assignResourceSharingClient(null) on all registered extensions. Before the fix,
+        // Kotlin's non-null parameter check would throw an NPE here.
+        val extension = ReportsSchedulerExtension()
+
+        // Simulate enable → disable cycle (exactly what the canary does)
+        val mockClient = mock(ResourceSharingClient::class.java)
+        assertDoesNotThrow { extension.assignResourceSharingClient(mockClient) }
+        assertDoesNotThrow { extension.assignResourceSharingClient(null) }
+
+        // After disable, client should be null
+        assertNull(ResourceSharingClientAccessor.getInstance().getResourceSharingClient())
+    }
+
+    @Test
+    fun `assignResourceSharingClient enables then disables without error`() {
+        // Simulates repeated enable/disable cycles
+        val extension = ReportsSchedulerExtension()
+        val mockClient = mock(ResourceSharingClient::class.java)
+
+        repeat(3) {
+            assertDoesNotThrow { extension.assignResourceSharingClient(mockClient) }
+            assertEquals(mockClient, ResourceSharingClientAccessor.getInstance().getResourceSharingClient())
+
+            assertDoesNotThrow { extension.assignResourceSharingClient(null) }
+            assertNull(ResourceSharingClientAccessor.getInstance().getResourceSharingClient())
+        }
+    }
+}


### PR DESCRIPTION
When the resource-sharing feature flag is disabled via cluster settings, the security plugin calls assignResourceSharingClient(null) on all registered ResourceSharingExtension implementations to clear the client.

The Kotlin non-null parameter declaration causes an immediate NPE in ClusterApplierService.applyChanges(), preventing cluster state from being published to follower nodes. The master steps down and re-election hits the same failure, creating an infinite election loop.

Fix: Change parameter types to nullable (ResourceSharingClient?) in both ReportsSchedulerExtension and ResourceSharingClientAccessor. The internal field was already declared nullable and getResourceSharingClient() already returns nullable, so all callers handle null correctly.

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
