### PR TITLE
Skip manual access checks when DocRequest-based authz is active

### DIFF
--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportDefinitionActions.kt
@@ -81,7 +81,9 @@ internal object ReportDefinitionActions {
                 throw OpenSearchStatusException("Report Definition ${request.reportDefinitionId} not found", RestStatus.NOT_FOUND)
             }
 
-        if (!UserAccessManager.doesUserHasAccess(user, currentReportDefinitionDetails.tenant, currentReportDefinitionDetails.access)) {
+        if (!shouldUseResourceAuthz(Utils.REPORT_DEFINITION_TYPE) &&
+            !UserAccessManager.doesUserHasAccess(user, currentReportDefinitionDetails.tenant, currentReportDefinitionDetails.access)
+        ) {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportDefinitionId}", RestStatus.FORBIDDEN)
         }
@@ -119,7 +121,9 @@ internal object ReportDefinitionActions {
                 throw OpenSearchStatusException("Report Definition ${request.reportDefinitionId} not found", RestStatus.NOT_FOUND)
             }
 
-        if (!UserAccessManager.doesUserHasAccess(user, reportDefinitionDetails.tenant, reportDefinitionDetails.access)) {
+        if (!shouldUseResourceAuthz(Utils.REPORT_DEFINITION_TYPE) &&
+            !UserAccessManager.doesUserHasAccess(user, reportDefinitionDetails.tenant, reportDefinitionDetails.access)
+        ) {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportDefinitionId}", RestStatus.FORBIDDEN)
         }
@@ -144,7 +148,9 @@ internal object ReportDefinitionActions {
                 throw OpenSearchStatusException("Report Definition ${request.reportDefinitionId} not found", RestStatus.NOT_FOUND)
             }
 
-        if (!UserAccessManager.doesUserHasAccess(user, reportDefinitionDetails.tenant, reportDefinitionDetails.access)) {
+        if (!shouldUseResourceAuthz(Utils.REPORT_DEFINITION_TYPE) &&
+            !UserAccessManager.doesUserHasAccess(user, reportDefinitionDetails.tenant, reportDefinitionDetails.access)
+        ) {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportDefinitionId}", RestStatus.FORBIDDEN)
         }

--- a/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportInstanceActions.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/action/ReportInstanceActions.kt
@@ -91,7 +91,9 @@ internal object ReportInstanceActions {
                 throw OpenSearchStatusException("Report Definition ${request.reportDefinitionId} not found", RestStatus.NOT_FOUND)
             }
 
-        if (!UserAccessManager.doesUserHasAccess(user, reportDefinitionDetails.tenant, reportDefinitionDetails.access)) {
+        if (!shouldUseResourceAuthz(Utils.REPORT_DEFINITION_TYPE) &&
+            !UserAccessManager.doesUserHasAccess(user, reportDefinitionDetails.tenant, reportDefinitionDetails.access)
+        ) {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportDefinitionId}", RestStatus.FORBIDDEN)
         }
@@ -145,7 +147,9 @@ internal object ReportInstanceActions {
                 Metrics.REPORT_INSTANCE_UPDATE_USER_ERROR_MISSING_REPORT_INSTANCE.counter.increment()
                 throw OpenSearchStatusException("Report Instance ${request.reportInstanceId} not found", RestStatus.NOT_FOUND)
             }
-        if (!UserAccessManager.doesUserHasAccess(user, currentReportInstance.tenant, currentReportInstance.access)) {
+        if (!shouldUseResourceAuthz(Utils.REPORT_INSTANCE_TYPE) &&
+            !UserAccessManager.doesUserHasAccess(user, currentReportInstance.tenant, currentReportInstance.access)
+        ) {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportInstanceId}", RestStatus.FORBIDDEN)
         }
@@ -184,7 +188,9 @@ internal object ReportInstanceActions {
                 throw OpenSearchStatusException("Report Instance ${request.reportInstanceId} not found", RestStatus.NOT_FOUND)
             }
 
-        if (!UserAccessManager.doesUserHasAccess(user, reportInstance.tenant, reportInstance.access)) {
+        if (!shouldUseResourceAuthz(Utils.REPORT_INSTANCE_TYPE) &&
+            !UserAccessManager.doesUserHasAccess(user, reportInstance.tenant, reportInstance.access)
+        ) {
             Metrics.REPORT_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for Report Definition ${request.reportInstanceId}", RestStatus.FORBIDDEN)
         }


### PR DESCRIPTION
With request classes implementing DocRequest, the security plugin enforces resource-sharing authz before the transport action runs. Guard the legacy UserAccessManager.doesUserHasAccess calls behind !shouldUseResourceAuthz so they only apply in the pre-resource-sharing backend-role path, avoiding a duplicate (and inconsistent) check when resource sharing is enabled.


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
